### PR TITLE
Update documentation for VM.statistics()

### DIFF
--- a/src/main/java/types/Vm.java
+++ b/src/main/java/types/Vm.java
@@ -412,6 +412,9 @@ public interface Vm extends VmBase {
     /**
      * Statistics data collected from this virtual machine.
      *
+     * Note that some statistics, notably memory.bufferd and memory.cahced are
+     * available only when oVirt Guest Agent is installed in the VM.
+     *
      * @author Marek Libra <mlibra@redhat.com>
      * @date 12 Dec 2016
      * @status added


### PR DESCRIPTION
Document that for some memory statistics to be available oVirt Guest
Agent has to be installed. This is especially true for oVirt before 4.2.
From oVirt 4.2 some (but not all) statistics are available from VirtIO
balloon device.