### PR TITLE
BZ2020168 - Removed references to Ruby SDK

### DIFF
--- a/src/main/java/001-Introduction.adoc
+++ b/src/main/java/001-Introduction.adoc
@@ -60,8 +60,6 @@ from the API server. For example:
 
 ** The https://github.com/oVirt/ovirt-engine-sdk/tree/master/sdk[oVirt Python SDK].
 
-** The https://github.com/oVirt/ovirt-engine-sdk-ruby/tree/master/sdk[oVirt Ruby SDK].
-
 ** The https://github.com/oVirt/ovirt-engine-sdk-java/tree/master/sdk[oVirt Java SDK].
 
 ** The https://curl.haxx.se[cURL] command line tool.

--- a/src/main/java/types/Initialization.java
+++ b/src/main/java/types/Initialization.java
@@ -46,13 +46,13 @@ public interface Initialization {
      * |===
      *
      * For more details on how to use _cloud-init_ see the examples in
-     * https://github.com/oVirt/ovirt-engine-sdk/blob/master/sdk/examples/start_vm_with_cloud_init.py[Python],
-     * https://github.com/oVirt/ovirt-engine-sdk-ruby/blob/master/sdk/examples/start_vm_with_cloud_init.rb[Ruby] and
+     * https://github.com/oVirt/ovirt-engine-sdk/blob/master/sdk/examples/start_vm_with_cloud_init.py[Python] and
      * https://github.com/oVirt/ovirt-engine-sdk-java/blob/master/sdk/src/test/java/org/ovirt/engine/sdk4/examples/StartVmWithCloudInit.java[Java].
      *
      * @author Juan Hernandez <juan.hernandez@redhat.com>
      * @author Byron Gravenorst <bgraveno@redhat.com>
-     * @date 25 Jul 2017
+     * @author Donna DaCosta <ddacosta@redhat.com>
+     * @date 16 Feb 2022
      * @status updated_by_docs
      */
     @Deprecated


### PR DESCRIPTION
Updated files to remove references to the Ruby SDK based on https://bugzilla.redhat.com/show_bug.cgi?id=2020168.