### PR TITLE
Add 'seal' parameter for created VMs

### DIFF
--- a/src/main/java/services/VmPoolService.java
+++ b/src/main/java/services/VmPoolService.java
@@ -168,6 +168,41 @@ public interface VmPoolService {
          * Indicates if the update should be performed asynchronously.
          */
         @In Boolean async();
+
+        /**
+         * Specifies if virtual machines created for the pool should be sealed after creation.
+         *
+         * If this optional parameter is provided, and its value is `true`, virtual machines created for the pool
+         * will be sealed after creation. If the value is 'false', the virtual machines will not be sealed.
+         * If the parameter is not provided, the virtual machines will be sealed, only if they are created from
+         * a sealed template and their guest OS is not set to Windows. This parameter affects only the virtual machines
+         * created when the pool is updated.
+         *
+         * For example, to update a virtual machine pool and to seal the additional virtual machines that are created,
+         * send a request like this:
+         *
+         * [source]
+         * ----
+         * PUT /ovirt-engine/api/vmpools/123?seal=true
+         * ----
+         *
+         * With the following body:
+         *
+         * [source,xml]
+         * ----
+         * <vmpool>
+         *   <name>VM_Pool_B</name>
+         *   <description>Virtual Machine Pool B</description>
+         *   <size>7</size>
+         * </vmpool>
+         * ----
+         *
+         * @author Shmuel Leib Melamud <smelamud@redhat.com>
+         * @date 1 Mar 2022
+         * @status added
+         * @since 4.5
+         */
+        @In Boolean seal();
     }
 
     /**

--- a/src/main/java/services/VmPoolsService.java
+++ b/src/main/java/services/VmPoolsService.java
@@ -89,6 +89,42 @@ public interface VmPoolsService {
          * @status added
          */
         @In @Out VmPool pool();
+
+        /**
+         * Specifies if virtual machines created for the pool should be sealed after creation.
+         *
+         * If this optional parameter is provided, and its value is `true`, virtual machines created for the pool
+         * will be sealed after creation. If the value is 'false', the virtual machines will not be sealed.
+         * If the parameter is not provided, the virtual machines will be sealed, only if they are created from
+         * a sealed template and their guest OS is not set to Windows. This parameter affects only the virtual machines
+         * created when the pool is created.
+         *
+         * For example, to create a virtual machine pool with 5 virtual machines and to seal them, send a request
+         * like this:
+         *
+         * [source]
+         * ----
+         * POST /ovirt-engine/api/vmpools?seal=true
+         * ----
+         *
+         * With the following body:
+         *
+         * [source,xml]
+         * ----
+         * <vmpool>
+         *   <name>mypool</name>
+         *   <cluster id="123"/>
+         *   <template id="456"/>
+         *   <size>5</size>
+         * </vmpool>
+         * ----
+         *
+         * @author Shmuel Leib Melamud <smelamud@redhat.com>
+         * @date 1 Mar 2022
+         * @status added
+         * @since 4.5
+         */
+        @In Boolean seal();
     }
 
     /**

--- a/src/main/java/services/VmsService.java
+++ b/src/main/java/services/VmsService.java
@@ -322,6 +322,44 @@ public interface VmsService {
         @Deprecated
         @In AutoPinningPolicy autoPinningPolicy();
 
+        /**
+         * Specifies if the virtual machine should be sealed after creation.
+         *
+         * If this optional parameter is provided, and its value is `true`, the virtual machine will be sealed after
+         * creation. If the value is 'false', the virtual machine will not be sealed. If the parameter is not provided,
+         * the virtual machine will be sealed, only if it is created from a sealed template and its guest OS is not set
+         * to Windows.
+         *
+         * For example, to create a virtual machine from the `mytemplate` template and to seal it, send a request
+         * like this:
+         *
+         * [source]
+         * ----
+         * POST /ovirt-engine/api/vms?seal=true
+         * ----
+         *
+         * With a request body like this:
+         *
+         * [source,xml]
+         * ----
+         * <vm>
+         *   <name>myvm<name>
+         *   <template>
+         *     <name>mytemplate<name>
+         *   </template>
+         *   <cluster>
+         *     <name>mycluster<name>
+         *   </cluster>
+         * </vm>
+         * ----
+         *
+         * @author Shmuel Leib Melamud <smelamud@redhat.com>
+         * @date 1 Mar 2022
+         * @status added
+         * @since 4.5
+         */
+        @In Boolean seal();
+
         @InputDetail
         default void inputDetail() {
             optional(vm().bios().bootMenu().enabled());


### PR DESCRIPTION
The 'seal' parameter is added to VM creation and to VM Pool creation and
update, when VMs may be created for the pool.

Change-Id: I46d9763fb909643a622a946b72b30d6d73659243
Signed-off-by: Shmuel Melamud <smelamud@redhat.com>
Bug-Url: https://bugzilla.redhat.com/2054681