### PR TITLE
use legacy crypto policy on el9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,10 @@ jobs:
           # DNF core plugins are installed in the official CS9 container image
           dnf install -y dnf-plugins-core
 
+          # use legacy crypto policy on el9
+          dnf upgrade -y crypto-policies-scripts crypto-policies
+          update-crypto-policies --set LEGACY
+
           # Install oVirt repositories
           dnf copr enable -y ovirt/ovirt-master-snapshot
           dnf install -y ovirt-release-master


### PR DESCRIPTION
recent openssl dropped support for sha1 algo but COPR and several
other packaging systems are still signing RPMS with sha1.
In order to be able to install RPMs switching from default crypto policy
to legacy one untill RPMS with newer sha signature will be provided.

This requires crypto-policies-20220223-1.git5203b41.el9 or newer.

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>