### PR TITLE
api-model: Add mediated devices

### DIFF
--- a/src/main/java/services/TemplateMediatedDeviceService.java
+++ b/src/main/java/services/TemplateMediatedDeviceService.java
@@ -1,0 +1,135 @@
+/*
+Copyright (C) 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services;
+
+import annotations.Area;
+import mixins.Follow;
+import org.ovirt.api.metamodel.annotations.In;
+import org.ovirt.api.metamodel.annotations.Out;
+import org.ovirt.api.metamodel.annotations.Service;
+import types.VmMediatedDevice;
+
+@Service
+@Area("Virtualization")
+public interface TemplateMediatedDeviceService {
+
+    /**
+     * Gets mediated device configuration of the template.
+     *
+     * @author Milan Zamazal <mzamazal@redhat.com>
+     * @date 10 Mar 2022
+     * @status added
+     * @since 4.5
+     */
+    interface Get extends Follow {
+        /**
+         * The information about the mediated device of the template.
+         *
+         * @author Milan Zamazal <mzamazal@redhat.com>
+         * @date 10 Mar 2022
+         * @status added
+         * @since 4.5
+         */
+        @Out VmMediatedDevice device();
+    }
+
+    /**
+     * Updates the information about the mediated device.
+     *
+     * You can update the information using `specParams` element.
+     *
+     * For example, to update a mediated device, send a request like this:
+     *
+     * [source]
+     * ----
+     * PUT /ovirt-engine/api/templates/123/mediateddevices/00000000-0000-0000-0000-000000000000
+     * <vm_mediated_device>
+     *   <spec_params>
+     *     <property>
+     *       <name>mdevType</name>
+     *       <value>nvidia-11</value>
+     *     </property>
+     *   </spec_params>
+     * </vm_mediated_device>
+     * ----
+     *
+     * with response body:
+     *
+     * [source,xml]
+     * ----
+     * <vm_mediated_device href="/ovirt-engine/api/templates/123/mediateddevices/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000">
+     *   <template href="/ovirt-engine/api/templates/123" id="123"/>
+     *   <spec_params>
+     *     <property>
+     *       <name>mdevType</name>
+     *       <value>nvidia-11</value>
+     *     </property>
+     *   </spec_params>
+     * </vm_mediated_device>
+     * ----
+     *
+     * @author Milan Zamazal <mzamazal@redhat.com>
+     * @date 10 Mar 2022
+     * @status added
+     * @since 4.5
+     */
+    interface Update {
+        /**
+         * The information about the mediated device.
+         *
+         * The request data must contain `specParams` properties.
+         * The response data contains complete information about the
+         * updated mediated device.
+         *
+         * @author Milan Zamazal <mzamazal@redhat.com>
+         * @date 10 Mar 2022
+         * @status added
+         * @since 4.5
+         */
+        @In @Out VmMediatedDevice devices();
+
+        /**
+         * Indicates if the update should be performed asynchronously.
+         *
+         * @author Milan Zamazal <mzamazal@redhat.com>
+         * @date 10 Mar 2022
+         * @status added
+         * @since 4.5
+         */
+        @In Boolean async();
+    }
+
+    /**
+     * Remove the mediated device from the template.
+     *
+     * @author Milan Zamazal <mzamazal@redhat.com>
+     * @date 10 Mar 2022
+     * @status added
+     * @since 4.5
+     */
+    interface Remove {
+        /**
+         * Indicates if the remove should be performed asynchronously.
+         *
+         * @author Milan Zamazal <mzamazal@redhat.com>
+         * @date 10 Mar 2022
+         * @status added
+         * @since 4.5
+         */
+        @In Boolean async();
+    }
+}

--- a/src/main/java/services/TemplateMediatedDevicesService.java
+++ b/src/main/java/services/TemplateMediatedDevicesService.java
@@ -1,0 +1,96 @@
+/*
+Copyright (C) 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services;
+
+import annotations.Area;
+import mixins.Follow;
+import org.ovirt.api.metamodel.annotations.In;
+import org.ovirt.api.metamodel.annotations.InputDetail;
+import org.ovirt.api.metamodel.annotations.Out;
+import org.ovirt.api.metamodel.annotations.Service;
+import types.VmMediatedDevice;
+
+import static org.ovirt.api.metamodel.language.ApiLanguage.mandatory;
+
+/**
+ * A service that manages mediated devices of a template.
+ *
+ * @author Milan Zamazal <mzamazal@redhat.com>
+ * @date 10 Mar 2022
+ * @status added
+ * @since 4.5
+ */
+@Service
+@Area("Virtualization")
+public interface TemplateMediatedDevicesService {
+
+    /**
+     * Add new mediated device to the template.
+     *
+     * @author Milan Zamazal <mzamazal@redhat.com>
+     * @date 10 Mar 2022
+     * @status added
+     * @since 4.5
+     */
+    interface Add {
+        @In @Out VmMediatedDevice device();
+    }
+
+    /**
+     * Lists all the configured mediated devices of the template.
+     *
+     * The order of the returned list of mediated devices isn't guaranteed.
+     *
+     * @author Milan Zamazal <mzamazal@redhat.com>
+     * @date 10 Mar 2022
+     * @status added
+     * @since 4.5
+     */
+    interface List extends Follow {
+
+        /**
+         * The list of mediated devices of the template.
+         *
+         * @author Milan Zamazal <mzamazal@redhat.com>
+         * @date 10 Mar 2022
+         * @status added
+         * @since 4.5
+         */
+        @Out VmMediatedDevice[] devices();
+
+        /**
+         * Sets the maximum number of mediated devices to return.
+         * If not specified all the mediated devices are returned.
+         *
+         * @author Milan Zamazal <mzamazal@redhat.com>
+         * @date 10 Mar 2022
+         * @status added
+         * @since 4.5
+         */
+        @In Integer max();
+    }
+
+    /**
+     * Returns a reference to the service that manages a mediated device of a template.
+     *
+     * @author Milan Zamazal <mzamazal@redhat.com>
+     * @date 10 Mar 2022
+     * @status added
+     * @since 4.5
+     */
+    @Service TemplateMediatedDeviceService device(String id);
+}

--- a/src/main/java/services/TemplateService.java
+++ b/src/main/java/services/TemplateService.java
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015 Red Hat, Inc.
+Copyright (c) 2015, 2022 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -413,4 +413,14 @@ public interface TemplateService {
      * @status updated_by_docs
      */
     @Service TemplateDiskAttachmentsService diskAttachments();
+
+    /**
+     * Reference to the service that manages mediated devices associated with the template.
+     *
+     * @author Milan Zamazal <mzamazal@redhat.com>
+     * @date 10 Mar 2022
+     * @status added
+     * @since 4.5
+     */
+    @Service TemplateMediatedDevicesService mediatedDevices();
 }

--- a/src/main/java/services/VmMediatedDeviceService.java
+++ b/src/main/java/services/VmMediatedDeviceService.java
@@ -1,0 +1,135 @@
+/*
+Copyright (c) 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services;
+
+import annotations.Area;
+import mixins.Follow;
+import org.ovirt.api.metamodel.annotations.In;
+import org.ovirt.api.metamodel.annotations.Out;
+import org.ovirt.api.metamodel.annotations.Service;
+import types.VmMediatedDevice;
+
+@Service
+@Area("Virtualization")
+public interface VmMediatedDeviceService {
+
+    /**
+     * Retrieves the configuration of mediated devices in the virtual machine.
+     *
+     * @author Milan Zamazal <mzamazal@redhat.com>
+     * @date 10 March 2022
+     * @status added
+     * @since 4.5
+     */
+    interface Get extends Follow {
+        /**
+         * The information about the mediated device of the virtual machine.
+         *
+         * @author Milan Zamazal <mzamazal@redhat.com>
+         * @date 10 Mar 2022
+         * @status added
+         * @since 4.5
+         */
+        @Out VmMediatedDevice device();
+    }
+
+    /**
+     * Updates the information about the mediated device.
+     *
+     * You can update the information using `specParams` element.
+     *
+     * For example, to update a mediated device, send a request like this:
+     *
+     * [source]
+     * ----
+     * PUT /ovirt-engine/api/vms/123/mediateddevices/00000000-0000-0000-0000-000000000000
+     * <vm_mediated_device>
+     *   <spec_params>
+     *     <property>
+     *       <name>mdevType</name>
+     *       <value>nvidia-11</value>
+     *     </property>
+     *   </spec_params>
+     * </vm_mediated_device>
+     * ----
+     *
+     * with response body:
+     *
+     * [source,xml]
+     * ----
+     * <vm_mediated_device href="/ovirt-engine/api/vms/123/mediateddevices/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000">
+     *   <vm href="/ovirt-engine/api/vms/123" id="123"/>
+     *   <spec_params>
+     *     <property>
+     *       <name>mdevType</name>
+     *       <value>nvidia-11</value>
+     *     </property>
+     *   </spec_params>
+     * </vm_mediated_device>
+     * ----
+     *
+     * @author Milan Zamazal <mzamazal@redhat.com>
+     * @date 10 Mar 2022
+     * @status added
+     * @since 4.5
+     */
+    interface Update {
+        /**
+         * The information about the mediated device.
+         *
+         * The request data must contain `specParams` properties.
+         * The response data contains complete information about the
+         * updated mediated device.
+         *
+         * @author Milan Zamazal <mzamazal@redhat.com>
+         * @date 10 Mar 2022
+         * @status added
+         * @since 4.5
+         */
+        @In @Out VmMediatedDevice device();
+
+        /**
+         * Indicates if the update should be performed asynchronously.
+         *
+         * @author Milan Zamazal <mzamazal@redhat.com>
+         * @date 10 Mar 2022
+         * @status added
+         * @since 4.5
+         */
+        @In Boolean async();
+    }
+
+    /**
+     * Remove the mediated device from the virtual machine.
+     *
+     * @author Milan Zamazal <mzamazal@redhat.com>
+     * @date 10 March 2022
+     * @status added
+     * @since 4.5
+     */
+    interface Remove {
+        /**
+         * Indicates if the remove should be performed asynchronously.
+         *
+         * @author Milan Zamazal <mzamazal@redhat.com>
+         * @date 10 Mar 2022
+         * @status added
+         * @since 4.5
+         */
+        @In Boolean async();
+    }
+}

--- a/src/main/java/services/VmMediatedDevicesService.java
+++ b/src/main/java/services/VmMediatedDevicesService.java
@@ -1,0 +1,93 @@
+/*
+Copyright (c) 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services;
+
+import annotations.Area;
+import mixins.Follow;
+import org.ovirt.api.metamodel.annotations.In;
+import org.ovirt.api.metamodel.annotations.Out;
+import org.ovirt.api.metamodel.annotations.Service;
+import types.VmMediatedDevice;
+
+/**
+ * A service that manages mediated devices of a VM.
+ *
+ * @author Milan Zamazal <mzamazal@redhat.com>
+ * @date 10 Mar 2022
+ * @status added
+ * @since 4.5
+ */
+@Service
+@Area("Virtualization")
+public interface VmMediatedDevicesService {
+
+    /**
+     * Add a new mediated device to the virtual machine.
+     *
+     * @author Milan Zamazal <mzamazal@redhat.com>
+     * @date 10 Mar 2022
+     * @status added
+     * @since 4.5
+     */
+    interface Add {
+        @In @Out VmMediatedDevice device();
+    }
+
+    /**
+     * Lists all the configured mediated devices of the virtual machine.
+     *
+     * The order of the returned list of mediated devices is not guaranteed.
+     *
+     * @author Milan Zamazal <mzamazal@redhat.com>
+     * @date 10 Mar 2022
+     * @status added
+     * @since 4.5
+     */
+    interface List extends Follow {
+
+        /**
+         * The list of mediated devices of the virtual machine.
+         *
+         * @author Milan Zamazal <mzamazal@redhat.com>
+         * @date 10 Mar 2022
+         * @status added
+         * @since 4.5
+         */
+        @Out VmMediatedDevice[] devices();
+
+        /**
+         * Sets the maximum number of mediated devices to return.
+         * If not specified all the mediated devices are returned.
+         *
+         * @author Milan Zamazal <mzamazal@redhat.com>
+         * @date 10 Mar 2022
+         * @status added
+         * @since 4.5
+         */
+        @In Integer max();
+    }
+
+    /**
+     * Returns a reference to the service that manages a mediated device of a virtual machine.
+     *
+     * @author Milan Zamazal <mzamazal@redhat.com>
+     * @date 10 Mar 2022
+     * @status added
+     * @since 4.5
+     */
+    @Service VmMediatedDeviceService device(String id);
+}

--- a/src/main/java/services/VmService.java
+++ b/src/main/java/services/VmService.java
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015 Red Hat, Inc.
+Copyright (c) 2015, 2022 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -1669,4 +1669,14 @@ public interface VmService extends MeasurableService {
      * @status updated_by_docs
      */
     @Service AssignedAffinityLabelsService affinityLabels();
+
+    /**
+     * Reference to the service that manages mediated devices associated with the VM.
+     *
+     * @author Milan Zamazal <mzamazal@redhat.com>
+     * @date 10 Mar 2022
+     * @status added
+     * @since 4.5
+     */
+    @Service VmMediatedDevicesService mediatedDevices();
 }

--- a/src/main/java/types/Template.java
+++ b/src/main/java/types/Template.java
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015-2016 Red Hat, Inc.
+Copyright (c) 2015-2022 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -128,4 +128,14 @@ public interface Template extends VmBase {
      * @status updated_by_docs
      */
     @Link DiskAttachment[] diskAttachments();
+
+    /**
+     * Mediated devices configuration.
+     *
+     * @author Milan Zamazal <mzamazal@redhat.com>
+     * @date 10 Mar 2022
+     * @status added
+     * @since 4.5
+     */
+    @Link VmMediatedDevice[] mediatedDevices();
 }

--- a/src/main/java/types/Vm.java
+++ b/src/main/java/types/Vm.java
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015-2016 Red Hat, Inc.
+Copyright (c) 2015-2022 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -398,4 +398,14 @@ public interface Vm extends VmBase {
      * @status added
      */
     @Link DynamicCpu dynamicCpu();
+
+    /**
+     * Mediated devices configuration.
+     *
+     * @author Milan Zamazal <mzamazal@redhat.com>
+     * @date 10 Mar 2022
+     * @status added
+     * @since 4.5
+     */
+    @Link VmMediatedDevice[] mediatedDevices();
 }

--- a/src/main/java/types/VmMediatedDevice.java
+++ b/src/main/java/types/VmMediatedDevice.java
@@ -1,0 +1,42 @@
+/*
+Copyright (c) 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types;
+
+import org.ovirt.api.metamodel.annotations.Type;
+
+/**
+ * VM mediated device is a fake device specifying properties of vGPU mediated devices.
+ * It is not an actual device, it just serves as a specification how to configure a part
+ * of a host device.
+ *
+ * @author Milan Zamazal <mzamazal@redhat.com>
+ * @date 10 Mar 2022
+ * @status added
+ * @since 4.5
+ */
+@Type
+public interface VmMediatedDevice extends Device {
+    /**
+     * Properties of the device.
+     *
+     * @author Milan Zamazal <mzamazal@redhat.com>
+     * @date 10 Mar 2022
+     * @status added
+     * @since 4.5
+     */
+    Property[] specParams();
+}


### PR DESCRIPTION
Support for vGPU mediated devices was previously handled by VM custom
properties.  We move from using custom properties for that purpose to
using fake VM devices.  Since there is no general support in the API
to handle VM devices, this patch introduces a special API entities for
dealing with mediated devices, similarly to graphics console
configuration.