### PR TITLE
Add snapshot field to backup

### DIFF
--- a/src/main/java/types/Backup.java
+++ b/src/main/java/types/Backup.java
@@ -103,4 +103,14 @@ public interface Backup extends Identified {
      * @since 4.3
      */
     @Link Disk[] disks();
+
+    /**
+     * A reference to the snapshot created if the backup is using a snapshot.
+     *
+     * @author Benny Zlotnik
+     * @date 10 Mar 2022
+     * @status added
+     * @since 4.5
+     */
+    @Link Snapshot snapshot();
 }


### PR DESCRIPTION
This field will contain the information of the snapshot created for hybrid backup, will remain empty if the backup is not hybrid.

Signed-off-by: Benny Zlotnik <bzlotnik@redhat.com>