### PR TITLE
Add upgrade progress tracking for Clusters

### DIFF
--- a/src/main/java/services/ClusterService.java
+++ b/src/main/java/services/ClusterService.java
@@ -271,9 +271,9 @@ public interface ClusterService {
      }
 
      /**
-      * Start or finish upgrade process for the cluster based on the action value. This action marks the cluster for
-      * upgrade or clears the upgrade running flag on the cluster based on the action value which takes values of
-      * start or stop.
+      * Start, update or finish upgrade process for the cluster based on the action value. This action marks the
+      * cluster for upgrade, updates the progress, or clears the upgrade running flag on the cluster based on the
+      * action value which takes values of `start`, `stop` or `update_progress`.
       *
       * [source]
       * ----
@@ -291,6 +291,20 @@ public interface ClusterService {
       * </action>
       * ----
       *
+      * After starting the upgrade, use a request body like this to update the progress to 15%:
+      *
+      * [source,xml]
+      * ----
+      * <action>
+      *     <upgrade_action>
+      *         update_progress
+      *     </upgrade_action>
+      *     <upgrade_percent_complete>
+      *         15
+      *     </upgrade_percent_complete>
+      * </action>
+      * ----
+      *
       * @author Ravi Nori <rnori@redhat.com>
       * @date 13 March 2019
       * @since 4.3.2
@@ -305,6 +319,26 @@ public interface ClusterService {
           * @status added
           */
          @In ClusterUpgradeAction upgradeAction();
+
+         /**
+          * Explicitly set the upgrade correlation identifier.  Use to correlate events
+          * detailing the cluster upgrade to the upgrade itself.  If not specificed, the
+          * correlation id from `Correlation-Id` http header will be used.
+          *
+          * @author Scott Dickerson <sdickers@redhat.com>
+          * @date 17 Mar 2022
+          * @since 4.5.0
+          */
+         @In String correlationId();
+
+         /**
+          * Update the upgrade's progress as a percent complete of the total process.
+          *
+          * @author Scott Dickerson <sdickers@redhat.com>
+          * @date 17 Mar 2022
+          * @since 4.5.0
+          */
+         @In Integer upgradePercentComplete();
 
          /**
           * Indicates if the action should be performed asynchronously.

--- a/src/main/java/types/Cluster.java
+++ b/src/main/java/types/Cluster.java
@@ -522,4 +522,32 @@ public interface Cluster extends Identified {
      * @since 4.4.5
      */
     FipsMode fipsMode();
+
+    /**
+     * Indicates if an upgrade has been started for the cluster.
+     *
+     * @author Scott Dickerson <sdickers@redhat.com>
+     * @date 17 Mar 2022
+     * @since 4.5.0
+     */
+    Boolean upgradeInProgress();
+
+    /**
+     * If an upgrade is in progress, the upgrade's reported percent complete.
+     *
+     * @author Scott Dickerson <sdickers@redhat.com>
+     * @date 17 Mar 2022
+     * @since 4.5.0
+     */
+    Integer upgradePercentComplete();
+
+    /**
+     * The upgrade correlation identifier. Use to correlate events detailing the cluster
+     * upgrade to the upgrade itself.
+     *
+     * @author Scott Dickerson <sdickers@redhat.com>
+     * @date 17 Mar 2022
+     * @since 4.5.0
+     */
+    String upgradeCorrelationId();
 }

--- a/src/main/java/types/ClusterUpgradeAction.java
+++ b/src/main/java/types/ClusterUpgradeAction.java
@@ -37,6 +37,18 @@ public enum ClusterUpgradeAction {
      * @status added
      */
     START,
+
+    /**
+     * The upgrade action to be passed to update the cluster upgrade progress. This should be used
+     * as the upgrade progresses.
+     *
+     * @author Scott Dickerson <sdickers@redhat.com>
+     * @date 16 Mar 2022
+     * @since 4.5.0
+     * @status added
+     */
+    UPDATE_PROGRESS,
+
     /**
      * The upgrade action to be passed to finish the cluster upgrade process by marking the cluster's
      * upgrade_running flag to false. This should be used at the end of the cluster upgrade process.


### PR DESCRIPTION
 - Add `UPDATE_PROGRESS` action to `ClusterUpgradeAction` so the ansible role can directly report upgrade progress.
 
 - Add `upgradeInProgress`, `upgradeProgress` and `upgradeCorrelationId` to the `Cluster` so the status and progress of an upgrade can be checked.

Bug-Url: https://bugzilla.redhat.com/2040474
Needed for: https://github.com/oVirt/ovirt-engine/pull/170
