### PR TITLE
Fixing cross refs

### DIFF
--- a/src/main/java/001-Introduction.adoc
+++ b/src/main/java/001-Introduction.adoc
@@ -1,4 +1,6 @@
-== Introduction
+:_content-type: ASSEMBLY
+[id="introduction"]
+= Introduction
 
 The {engine-name} provides a *Representational State Transfer (REST)
 API*. The API provides software developers and system administrators
@@ -36,7 +38,8 @@ aims to provide developers and administrators with instructions and
 examples to help harness the functionality of their {product-name}
 environment through the API, either directly or using the provided SDKs.
 
-=== Representational State Transfer
+[id="representational-state-transfer"]
+== Representational State Transfer
 
 *Representational State Transfer (REST)* is a design architecture that
 focuses on resources for a specific service and their representations. A
@@ -49,6 +52,7 @@ between the client and server where each request acts independently of any
 other request, and contains all the information necessary to complete the
 request.
 
+[id="api-prerequisites"]
 === API Prerequisites
 
 Prerequisites for using the {product-name} API:
@@ -58,13 +62,13 @@ Prerequisites for using the {product-name} API:
 * A client or programming library that initiates and receives HTTP requests
 from the API server. For example:
 
-** The https://github.com/oVirt/ovirt-engine-sdk/tree/master/sdk[oVirt Python SDK].
+** The link:https://github.com/oVirt/python-ovirt-engine-sdk4[oVirt Python SDK].
 
-** The https://github.com/oVirt/ovirt-engine-sdk-java/tree/master/sdk[oVirt Java SDK].
+** The link:https://github.com/oVirt/ovirt-engine-sdk-java/tree/master/sdk[oVirt Java SDK].
 
-** The https://curl.haxx.se[cURL] command line tool.
+** The link:https://curl.haxx.se[cURL] command line tool.
 
-** https://addons.mozilla.org/en-US/firefox/addon/restclient[RESTClient], a
+** link:https://addons.mozilla.org/en-US/firefox/addon/restclient[RESTClient], a
 debugger for RESTful web services.
 
 * Knowledge of Hypertext Transfer Protocol (HTTP), the protocol
@@ -74,6 +78,5 @@ at http://www.ietf.org/rfc/rfc2616.txt.
 
 * Knowledge of Extensible Markup Language (XML) or JavaScript Object
 Notation (JSON), which the API uses to construct resource representations.
-The W3C provides a full specification on XML at http://www.w3.org/TR/xml.
-ECMA International provide a free publication on JSON at
-http://www.ecma-international.org.
+The W3C provides a link:http://www.w3.org/TR/xml[full specification on XML].
+ECMA International provides a link:http://www.ecma-international.org[free publication on JSON].

--- a/src/main/java/002-AuthenticationAndSecurity.adoc
+++ b/src/main/java/002-AuthenticationAndSecurity.adoc
@@ -1,16 +1,18 @@
-== Authentication and Security
+:_content-type: ASSEMBLY
+[id="authentication-and-security"]
+= Authentication and Security
 
-=== TLS/SSL Certification
+== TLS/SSL Certification
 
 The {product-name} API requires Hypertext Transfer Protocol Secure
 (HTTPS) footnote:[HTTPS is described in
-http://tools.ietf.org/html/rfc2818[RFC 2818 HTTP Over TLS.]] for secure
+link:http://tools.ietf.org/html/rfc2818[RFC 2818 HTTP Over TLS].] for secure
 interaction with client software, such as the SDK and CLI components.
 This involves obtaining the
-https://en.wikipedia.org/wiki/Certificate_authority[CA] certificate used by the
+link:https://en.wikipedia.org/wiki/Certificate_authority[CA] certificate used by the
 server, and importing it into the certificate store of your client.
 
-==== Obtaining the CA Certificate
+=== Obtaining the CA Certificate
 
 You can obtain the CA certificate from the {engine-name} and transfer it
 to the client machine using one of these methods:
@@ -141,28 +143,28 @@ Each of these methods results in a certificate file named `ca.crt` on
 your client machine. You must then import this file into the certificate
 store of the client.
 
-==== Importing a Certificate to a Client
+=== Importing a Certificate to a Client
 
 Importing a certificate to a client relies on how the client
 stores and interprets certificates. See your client documentation for more
 information on importing a certificate.
 
-=== Authentication
+== Authentication
 
 Any user with a {engine-name} account has access to the API. All
 requests must be authenticated using either *OAuth* or basic
 authentication, as described below.
 
-==== OAuth Authentication
+=== OAuth Authentication
 
 Since version 4.0 of {product-name} the preferred authentication
-mechanism is https://oauth.net/2[OAuth 2.0], as described in
-https://tools.ietf.org/html/rfc6749[RFC 6749].
+mechanism is link:https://oauth.net/2[OAuth 2.0], as described in
+link:https://tools.ietf.org/html/rfc6749[RFC 6749].
 
 *OAuth* is a sophisticated protocol, with several mechanisms for obtaining
 authorization and access tokens. For use with the {product-name}
 API, the only supported one is the _Resource Owner Password Credentials
-Grant_, as described in https://tools.ietf.org/html/rfc6749#section-4.3[section 4.3]
+Grant_, as described in link:https://tools.ietf.org/html/rfc6749#section-4.3[section 4.3]
 of RFC 6749.
 
 You must first obtain a _token_, sending the user name and password
@@ -197,7 +199,7 @@ and `password` parameters:
 |===
 
 These parameters must be
-https://en.wikipedia.org/wiki/Percent-encoding[URL-encoded]. For example,
+link:https://en.wikipedia.org/wiki/Percent-encoding[URL-encoded]. For example,
 the `@` character in the user name needs to be encoded as `%40`. The
 resulting request body will be something like this:
 
@@ -249,14 +251,14 @@ When this happens, a new token is needed, as the {engine-name} single sign-on
 service does not currently support refreshing tokens. A new token can be
 requested using the same method described above.
 
-==== Basic Authentication
+=== Basic Authentication
 
 IMPORTANT: Basic authentication is supported only for backwards
 compatibility; it is deprecated since version 4.0 of {product-name},
 and will be removed in the future.
 
 Each request uses HTTP Basic Authentication footnote:[Basic
-Authentication is described in http://tools.ietf.org/html/rfc2617[RFC
+Authentication is described in link:http://tools.ietf.org/html/rfc2617[RFC
 2617 HTTP Authentication: Basic and Digest Access Authentication].] to
 encode the credentials. If a request does not include an appropriate
 `Authorization` header, the server sends a `401 Authorization Required` response:
@@ -274,7 +276,7 @@ in the supplied credentials with the `username@domain:password`
 convention.
 
 The following table shows the process for encoding credentials in
-https://tools.ietf.org/html/rfc4648[Base64].
+link:https://tools.ietf.org/html/rfc4648[Base64].
 
 .Encoding credentials for API access
 |===
@@ -316,13 +318,13 @@ and terminate each line with a newline character. This breaks the header
 and causes a faulty request. The `Authorization` header requires the
 encoded credentials on a single line within the header.
 
-==== Authentication Sessions
+=== Authentication Sessions
 
 The API also provides authentication session support. Send an initial request
 with authentication details, then send all subsequent requests using a session
 cookie to authenticate.
 
-===== Requesting an Authenticated Session
+==== Requesting an Authenticated Session
 
 . Send a request with the `Authorization` and `Prefer: persistent-auth`
 headers:

--- a/src/main/java/003-CommonConcepts.adoc
+++ b/src/main/java/003-CommonConcepts.adoc
@@ -1,26 +1,28 @@
-== Common concepts
+:_content-type: ASSEMBLY
+[id="common-concepts"]
+= Common concepts
 
-=== Types
+== Types
 
 The API uses the _type_ concept to describe the different kinds of objects
 accepted and returned.
 
 There are three relevant kinds of types:
 
-Primitive types:: Describe simple kinds of objects, like <<types/string, strings>> or
-<<types/integer, integers>>.
+Primitive types:: Describe simple kinds of objects, like xref:types/string[strings] or
+xref:types/integer[integers].
 
-Enumerated types:: Describe lists of valid values like <<types/vm_status, VmStatus>>
-or <<types/disk_format, DiskFormat>>.
+Enumerated types:: Describe lists of valid values like xref:types/vm_status[VmStatus]
+or xref:types/disk_format[DiskFormat].
 
 Structured types:: Describe structured objects, with multiple attributes and
-links, like <<types/vm, Vm>> or <<types/disk, Disk>>.
+links, like xref:types/vm[Vm] or xref:types/disk[Disk].
 
-=== Identified types
+== Identified types
 
 Many of the types used by the API represent _identified_ objects, objects
 that have an unique identifier and exist independently of other objects.
-The types used to describe those objects extend the <<types/identified, Identified>>
+The types used to describe those objects extend the xref:types/identified[Identified]
 type, which contains the following set of common attributes:
 
 [cols="20,20,60"]
@@ -28,48 +30,48 @@ type, which contains the following set of common attributes:
 |Attribute |Type |Description
 
 |`id`
-|<<types/string, String>>
+|xref:types/string[String]
 |Each object in the virtualization infrastructure contains an `id`, which
 acts as an unique identifier.
 
 |`href`
-|<<types/string, String>>
+|xref:types/string[String]
 |The canonical location of the object as an absolute path.
 
 |`name`
-|<<types/string, String>>
+|xref:types/string[String]
 |A user-supplied human readable name for the object. The `name` name is
 unique across all objects of the same type.
 
 |`description`
-|<<types/string, String>>
+|xref:types/string[String]
 |A free-form user-supplied human readable description of the object.
 
 |===
 
 IMPORTANT: Currently for most types of objects the `id` attribute is actually a
-randomly generated https://en.wikipedia.org/wiki/Universally_unique_identifier[UUID],
+randomly generated link:https://en.wikipedia.org/wiki/Universally_unique_identifier[UUID],
 but this is an implementation detail, and users should not rely on that, as
 it may change in the future. Instead users should assume that these
 identifiers are just strings.
 
-=== Objects
+== Objects
 
 Objects are the individual instances of the types supported by the API.
 For example, the virtual machine with identifier `123` is an object of
-the <<types/vm, Vm>> type.
+the xref:types/vm[Vm] type.
 
-=== Collections
+== Collections
 
 A collection is a set of objects of the same type.
 
-=== Representations
+== Representations
 
 The state of objects needs to be represented when it is transferred
 beetween the client and the server. The API supports XML and JSON as the
 representation of the state of objects, both for input and output.
 
-==== XML representation
+=== XML representation
 
 The XML representation of an object consists of an XML element
 corresponding to the type of the object, XML attributes for the `id` and
@@ -116,7 +118,7 @@ IMPORTANT: In the XML representation of objects the `id` and `href`
 attributes are the only ones that are represented as XML attributes, the
 rest are represented as nested XML elements.
 
-==== JSON representation
+=== JSON representation
 
 The JSON representation of an object consists of a JSON document
 containing a name/value pair for each attribute (including `id` and
@@ -163,7 +165,7 @@ a collection of virtual machines appears as follows:
 }
 ....
 
-=== Services
+== Services
 
 Services are the parts of the server responsible for retrieving, adding
 updating, removing and executing actions on the objects supported by the
@@ -173,12 +175,12 @@ There are two relevant kinds of services:
 
 Services that manage a collection of objects:: These services are
 reponsible for listing existing objects and adding new objects. For
-example, the <<services/vms, Vms>> service is responsible for managing
+example, the xref:services/vms[Vms] service is responsible for managing
 the collection of virtual machines available in the system.
 
 Services that manage a specific object:: These services are responsible
 for retrieving, updating, deleting and executing actions in specific
-objects. For example, the <<services/vm, Vm>> service is responsible for
+objects. For example, the xref:services/vm[Vm] service is responsible for
 managing a specific virtual machine.
 
 Each service is accessible via a particular _path_ within the server.
@@ -192,8 +194,8 @@ operations that they can perform. The services that manage collections
 of objects usually have the `list` and `add` methods. The services that
 manage specific objects usually have the `get`, `update` and `remove`
 methods. In addition, services may also have _action_ methods, that
-represent less common operations. For example, the <<services/vm, Vm>>
-service has a <<services/vm/methods/start, start>> method that is used
+represent less common operations. For example, the xref:services/vm[Vm]
+service has a xref:services/vm/methods/start[start] method that is used
 to start a virtual machine.
 
 For the more usual methods there is a direct mapping between the name of
@@ -241,14 +243,14 @@ main parameter per method.
 Secondary parameters:: The rest of the parameters.
 
 For example, the operation that adds a virtual machine (see
-<<services/vms/methods/add, here>>) has three parameters: `vm`, `clone`
+xref:services/vms/methods/add[here]) has three parameters: `vm`, `clone`
 and `clone_permissions`. The main parameter is `vm`, as it describes the
 object that is added. The `clone` and `clone_permissions` parameters are
 secondary parameters.
 
 The main parameter, when used for input, must be included in the body of
 the HTTP request. For example, when adding a virtual machine, the `vm`
-parameter, of type <<types/vm, Vm>>, must be included in the request
+parameter, of type xref:types/vm[Vm] must be included in the request
 body. So the complete request to add a virtual machine, including all
 the HTTP details, must look like this:
 
@@ -314,10 +316,10 @@ Accept: application/xml
 Action methods only have secondary parameters. They can be used for
 input and output, and they should be included in the request body,
 wrapped with an `action` element. For example, the action method used to
-start a virtual machine (see <<services/vm/methods/start, here>>) has a
+start a virtual machine (see xref:services/vm/methods/start[here]) has a
 `vm` parameter to describe how the virtual machine should be started,
 and a `use_cloud_init` parameter to specify if
-https://cloudinit.readthedocs.io[cloud-init] should be used to configure
+link:https://cloudinit.readthedocs.io[cloud-init] should be used to configure
 the guest operating system. So the complete request to start virtual
 machine `123` using _cloud-init_ will look like this when using XML:
 
@@ -350,7 +352,7 @@ Accept: application/xml
 </action>
 ....
 
-=== Searching
+== Searching
 
 The `list` method of some services has a `search` parameter that can be
 used to specify search criteria. When used, the server will only return
@@ -361,7 +363,7 @@ the following request will return only the virtual machine named `myvm`:
 GET /ovirt-engine/api/vms?search=name%3Dmyvm
 ....
 
-==== Maximum results parameter
+=== Maximum results parameter
 
 Use the `max` parameter to limit the number of objects returned. For
 example, the following request will only return one virtual machine,
@@ -375,7 +377,7 @@ A search request without the `max` parameter will return all the
 objects. Specifying the `max` parameter is recommended to reduce the
 impact of requests in the overall performance of the system.
 
-==== Case sensitivity
+=== Case sensitivity
 
 By default queries are not case sensitive. For example, the following
 request will return the virtual machines named `myvm`, `MyVM` and `MYVM`:
@@ -392,7 +394,7 @@ not `MyHost` or `MYHOST`, send a request like this:
 GET /ovirt-engine/api/vms?search=name%3D=myvm&case_sensitive=true
 ....
 
-==== Search syntax
+=== Search syntax
 
 The `search` parameters use the same syntax as the {product-name} query
 language:
@@ -435,7 +437,7 @@ sorted by the the value of their `time` attribute in descending order.
 |===
 
 The value of the `search` parameter must be
-https://en.wikipedia.org/wiki/Percent-encoding[URL-encoded] to translate
+link:https://en.wikipedia.org/wiki/Percent-encoding[URL-encoded] to translate
 reserved characters, such as operators and spaces. For example, the
 equal sign should be encoded as `%3D`:
 
@@ -443,7 +445,7 @@ equal sign should be encoded as `%3D`:
 GET /ovirt-engine/api/vms?search=name%3Dmyvm
 ....
 
-==== Wildcards
+=== Wildcards
 
 The asterisk can be used as part of a value, to indicate that any string
 matches, including the emtpy string. For example, the following request
@@ -454,7 +456,7 @@ such as `myvm`, `myvm2`, `myvma` or `myvm-webserver`:
 GET /ovirt-engine/api/vms?search=name%3Dmyvm*
 ....
 
-==== Pagination
+=== Pagination
 
 Some {product-name} environments contain large collections of objects.
 Retrieving all of them with one request isn't practical, and hurts
@@ -500,7 +502,7 @@ duplicates.
 ====
 
 [id="documents/003_common_concepts/follow"]
-=== Following links
+== Following links
 
 The API returns references to related objects as _links_. For example, when
 a virtual machine is retrieved it contains links to its disk attachments
@@ -645,7 +647,7 @@ especially in large scale environments. Make sure to test your application
 in a realistic environment, and use the `follow` parameter only when
 justified.
 
-=== Permissions
+== Permissions
 
 Many of the services that manage a single object provide a reference to
 a `permissions` service that manages the permissions assigned to that
@@ -675,7 +677,7 @@ A permission is added to an object sending a `POST` request with a
 permission representation to this service. Each new permission requires
 a role and a user.
 
-=== Handling errors
+== Handling errors
 
 Some errors require further explanation beyond a standard HTTP status
 code. For example, the API reports an unsuccessful object state update

--- a/src/main/java/004-QuickStartExample.adoc
+++ b/src/main/java/004-QuickStartExample.adoc
@@ -1,4 +1,6 @@
-== Quick Start Examples
+:_content-type: ASSEMBLY
+[id="quick-start-examples"]
+= Quick Start Examples
 
 The examples in this section show you how to use the REST API to set up
 a basic {product-name} environment and to create a virtual machine.
@@ -34,9 +36,9 @@ environment.
 
 In many examples, some attributes of the results returned by the
 API have been omitted, for brevity. See, for example, the
-<<types/cluster, Cluster>> reference for a complete list of attributes.
+xref:types/cluster[Cluster] reference for a complete list of attributes.
 
-=== Access API entry point
+== Access API entry point
 
 The following request retrieves a representation of the main entry point
 for version 4 of the API:
@@ -67,7 +69,7 @@ curl \
 https://myengine.example.com/ovirt-engine/api
 ....
 
-The result is an object of type <<types/api, Api>>:
+The result is an object of type xref:types/api[Api]:
 
 [source,xml]
 ----
@@ -135,12 +137,11 @@ provides a reference point for each link. The next step in this example
 examines the data center collection, which is available through the
 `datacenters` link.
 
-The entry point also contains other data such as <<types/product_info,
-product_info>>, <<types/special_objects, special_objects>> and
-<<types/api_summary, summary>>. This data is covered in chapters
+The entry point also contains other data such as xref:types/product_info[product_info], xref:types/special_objects[special_objects] and
+xref:types/api_summary[summary]. This data is covered in chapters
 outside this example.
 
-=== List data centers
+== List data centers
 
 {product-name} creates a `Default` data center on installation. This
 example uses the `Default` data center as the basis for the virtual
@@ -165,8 +166,7 @@ The same request, using the `curl` command:
 https://myengine.example.com/ovirt-engine/api/datacenters
 ....
 
-The result will be a list of objects of type <<types/data_center,
-DataCenter>>:
+The result will be a list of objects of type xref:types/data_center[DataCenter]:
 
 [source,xml]
 ----
@@ -199,7 +199,7 @@ Note the `id` of your `Default` data center. It identifies this data
 center in relation to other resources of your virtual environment.
 
 The data center also contains a link to the
-<<services/attached_storage_domains, service>> that manages the storage
+xref:services/attached_storage_domains[service] that manages the storage
 domains attached to the data center:
 
 ....
@@ -209,7 +209,7 @@ domains attached to the data center:
 That service is used to attach storage domains from the main
 `storagedomains` collection, which this example covers later.
 
-=== List host clusters
+== List host clusters
 
 {product-name} creates a `Default` hosts cluster on installation. This
 example uses the `Default` cluster to group resources in your
@@ -235,7 +235,7 @@ curl \
 https://myengine.example.com/ovirt-engine/api/clusters
 ....
 
-The result will be a list of objects of type <<types/cluster, Cluster>>:
+The result will be a list of objects of type xref:types/cluster[Cluster]:
 
 [source,xml]
 ----
@@ -271,11 +271,10 @@ through a relationship using the `id` and `href` attributes of the
 <data_center href="/ovirt-engine/api/datacenters/001" id="001"/>
 ....
 
-The `networks` link is a reference to the <<services/data_center_networks,
-service>> that manages the networks associated to this cluster. The next
+The `networks` link is a reference to the xref:services/data_center_networks[service] that manages the networks associated to this cluster. The next
 section examines the networks collection in more detail.
 
-=== List logical networks
+== List logical networks
 
 {product-name} creates a default `ovirtmgmt` network on installation.
 This network acts as the management network for {engine-name} to access
@@ -304,7 +303,7 @@ The same request, using the `curl` command:
 https://myengine.example.com/ovirt-engine/api/networks
 ....
 
-The result will be a list of objects of type <<types/network, Network>>:
+The result will be a list of objects of type xref:types/network[Network]:
 
 [source,xml]
 ----
@@ -332,7 +331,7 @@ relationship using the data center's `id`.
 The `ovirtmgmt` network is also attached to the `Default` cluster through a
 relationship in the cluster's network sub-collection.
 
-=== List hosts
+== List hosts
 
 This example retrieves the list of hosts and shows a host named `myhost`
 registered with the virtualization environment:
@@ -355,7 +354,7 @@ The same request, using the `curl` command:
 https://myengine.example.com/ovirt-engine/api/hosts
 ....
 
-The result will be a list of objects of type <<types/host, Host>>:
+The result will be a list of objects of type xref:types/host[Host]:
 
 [source,xml]
 ----
@@ -397,7 +396,7 @@ This host is a member of the `Default` cluster and accessing the `nics`
 sub-collection shows this host has a connection to the `ovirtmgmt`
 network.
 
-=== Create NFS data storage
+== Create NFS data storage
 
 An NFS data storage domain is an exported NFS share attached to a data
 center and provides storage for virtualized guest images. Creation of a
@@ -469,7 +468,7 @@ https://myengine.example.com/ovirt-engine/api/storagedomains
 The server uses host `myhost` to create a NFS data storage domain called
 `mydata` with an export path of `mynfs.example.com:/exports/mydata`. The
 API also returns the following representation of the newly created
-storage domain resource (of type <<types/storage_domain, StorageDomain>>):
+storage domain resource (of type xref:types/storage_domain[StorageDomain]):
 
 [source,xml]
 ----
@@ -491,7 +490,7 @@ storage domain resource (of type <<types/storage_domain, StorageDomain>>):
 </storage_domain>
 ----
 
-=== Create NFS ISO storage
+== Create NFS ISO storage
 
 An NFS ISO storage domain is a mounted NFS share attached to a data
 center and provides storage for DVD/CD-ROM ISO and virtual floppy disk
@@ -557,7 +556,7 @@ https://myengine.example.com/ovirt-engine/api/storagedomains
 The server uses host `myhost` to create a NFS ISO storage domain called
 `myisos` with an export path of `mynfs.example.com:/exports/myisos`. The
 API also returns the following representation of the newly created
-storage domain resource (of type <<types/storage_domain, StorageDomain>>):
+storage domain resource (of type xref:types/storage_domain[StorageDomain]):
 
 [source,xml]
 ----
@@ -579,7 +578,7 @@ storage domain resource (of type <<types/storage_domain, StorageDomain>>):
 </storage_domain>
 ----
 
-=== Attach storage domains to data center
+== Attach storage domains to data center
 
 The following example attaches the `mydata` and `myisos` storage domains
 to the `Default` data center.
@@ -654,14 +653,14 @@ The same request, using the `curl` command:
 https://myengine.example.com/ovirt-engine/api/datacenters/001/storagedomains
 ....
 
-=== Create virtual machine
+== Create virtual machine
 
 The following example creates a virtual machine called `myvm` on the
 `Default` cluster using the virtualization environment's `Blank`
 template as a basis. The request also defines the virtual machine's
 memory as 512 MiB and sets the boot device to a virtual hard disk.
 
-The request should be contain an object of type <<types/vm, Vm>>
+The request should be contain an object of type xref:types/vm[Vm]
 describing the virtual machine to create:
 
 [source,xml]
@@ -728,7 +727,7 @@ The same request, using the `curl` command:
 https://myengine.example.com/ovirt-engine/api/vms
 ....
 
-The response body will be an object of the <<types/vm, Vm>> type:
+The response body will be an object of the xref:types/vm[Vm] type:
 
 [source,xml]
 ----
@@ -762,7 +761,7 @@ The response body will be an object of the <<types/vm, Vm>> type:
 </vm>
 ----
 
-=== Create a virtual machine NIC
+== Create a virtual machine NIC
 
 The following example creates a virtual network interface to connect the
 example virtual machine to the `ovirtmgmt` network.
@@ -775,7 +774,7 @@ Content-Type: application/xml
 Accept: application/xml
 ....
 
-The request body should contain an object of type <<types/nic, Nic>>
+The request body should contain an object of type xref:types/nic[Nic]
 describing the NIC to be created:
 
 [source,xml]
@@ -805,7 +804,7 @@ The same request, using the `curl` command:
 https://myengine.example.com/ovirt-engine/api/vms/007/nics
 ....
 
-=== Create virtual machine disk
+== Create virtual machine disk
 
 The following example creates an 8 GiB _copy-on-write_ disk for the
 example virtual machine.
@@ -818,8 +817,7 @@ Content-Type: application/xml
 Accept: application/xml
 ....
 
-The request body should be an object of type <<types/disk_attachment,
-DiskAttachment>> describing the disk and how it will be attached to the
+The request body should be an object of type xref:types/disk_attachment[DiskAttachment] describing the disk and how it will be attached to the
 virtual machine:
 
 [source,xml]
@@ -876,15 +874,15 @@ https://myengine.example.com/ovirt-engine/api/vms/007/diskattachments
 The `storage_domains` attribute tells the API to store the disk on the
 `mydata` storage domain.
 
-=== Attach ISO image to virtual machine
+== Attach ISO image to virtual machine
 
 The boot media for the following virtual machine example requires a CD-ROM or DVD
 ISO image for an operating system installation. This example uses a
 CentOS 7 image.
 
 ISO images must be available in the `myisos` ISO domain for the virtual
-machines to use. You can use <<services/image_transfers>> to create an
-image transfer and <<services/image_transfer>> to upload the ISO
+machines to use. You can use xref:services/image_transfer[ImageTransfer] to create an
+image transfer and xref:services/image_transfers[ImageTransfers] to upload the ISO
 image.
 
 Once the ISO image is uploaded, an API can be used to request the list of
@@ -907,8 +905,7 @@ The same request, using the `curl` command:
 https://myengine.example.com/ovirt-engine/api/storagedomains/006/files
 ....
 
-The server returns the following list of objects of type <<types/file,
-File>>, one for each available ISO (or floppy) image:
+The server returns the following list of objects of type xref:types/file[File], one for each available ISO (or floppy) image:
 
 [source,xml]
 ----
@@ -932,7 +929,7 @@ Accept: application/xml
 Content-type: application/xml
 ....
 
-The request body should be an object of type <<types/cdrom, Cdrom>>
+The request body should be an object of type xref:types/cdrom[Cdrom]
 containing an inner `file` attribute to indicate the identifier of the
 ISO (or floppy) image:
 
@@ -961,14 +958,13 @@ The same request, using the `curl` command:
 https://myengine.example.com/ovirt-engine/api/vms/007/cdroms/00000000-0000-0000-0000-000000000000
 ....
 
-For more details see the documentation of the <<services/vm_cdrom,
-service>> that manages virtual machine CD-ROMS.
+For more details see the documentation of the xref:services/vm_cdrom[service] that manages virtual machine CD-ROMS.
 
-=== Start the virtual machine
+== Start the virtual machine
 
 The virtual environment is complete and the virtual machine contains all
 necessary components to function. This example starts the virtual
-machine using the <<services/vm/methods/start, start>> method.
+machine using the xref:services/vm/methods/start[start] method.
 
 The request should be like this:
 

--- a/src/main/java/A01-PrimitiveTypes.adoc
+++ b/src/main/java/A01-PrimitiveTypes.adoc
@@ -1,15 +1,17 @@
 [appendix]
-== Primitive types
+:_content-type: ASSEMBLY
+[id="primitive-types"]
+= Primitive types
 
 This section describes the primitive data types supported by the API.
 
 [id="types/string"]
-=== String [small]#primitive#
+== String [small]#primitive#
 
-A finite sequence of https://home.unicode.org[Unicode] characters.
+A finite sequence of link:https://home.unicode.org[Unicode] characters.
 
 [id="types/boolean"]
-=== Boolean [small]#primitive#
+== Boolean [small]#primitive#
 
 Represents the _false_ and _true_ concepts used in mathematical logic.
 
@@ -24,7 +26,7 @@ than `false`, and `1` has the same meaning than `true`. Try to avoid
 using these values, as support for them may be removed in the future.
 
 [id="types/integer"]
-=== Integer [small]#primitive#
+== Integer [small]#primitive#
 
 Represents the mathematical concept of integer number.
 
@@ -64,12 +66,12 @@ unlimited precission integers, so the above limitations and exceptions
 will eventually disappear.
 
 [id="types/decimal"]
-=== Decimal [small]#primitive#
+== Decimal [small]#primitive#
 
 Represents the mathematical concept of real number.
 
 Currently the engine implements this type using 32 bit
-https://en.wikipedia.org/wiki/IEEE_floating_point[IEEE 754] single
+link:https://en.wikipedia.org/wiki/IEEE_floating_point[IEEE 754] single
 precision floating point numbers.
 
 For some attributes this isn't enough precision. In those exceptional
@@ -85,12 +87,12 @@ precision decimal numbers, so the above limitations and exceptions will
 eventually disappear.
 
 [id="types/date"]
-=== Date [small]#primitive#
+== Date [small]#primitive#
 
 Represents a date and time.
 
 The format returned by the engine is the one described in the
-https://www.w3.org/TR/xmlschema11-2/#dateTime[XML Schema specification]
+link:https://www.w3.org/TR/xmlschema11-2/#dateTime[XML Schema specification]
 when requesting XML. For example, if you send a request like this to
 retrieve the XML representation of a virtual machine:
 
@@ -113,7 +115,7 @@ The response body will contain the following XML document:
 
 When requesting the JSON representation the engine uses a different,
 format: an integer containing the number of milliseconds since Jan 1^st^ 1970,
-also known as https://en.wikipedia.org/wiki/Unix_time[_epoch time_]. For
+also known as link:https://en.wikipedia.org/wiki/Unix_time[_epoch time_]. For
 example, if you send a request like this to retrieve the JSON
 representation of a virtual machine:
 

--- a/src/main/java/A02-ChangesInV4.adoc
+++ b/src/main/java/A02-ChangesInV4.adoc
@@ -1,16 +1,18 @@
 [appendix]
-== Changes in version 4 of the API
+:_content-type: ASSEMBLY
+[id="changes-in-version-4-of-the-api"]
+= Changes in version 4 of the API
 
 This section enumerates the backwards-compatibility breaking changes that
 have been introduced in and since version 4 of the API.
 
-=== Changes in API version 4.0 (succeeding version 3.6)
+== Changes in API version 4.0 (succeeding version 3.6)
 
-==== Removed YAML support
+=== Removed YAML support
 
 The support for YAML has been completely removed.
 
-==== Renamed complex types
+=== Renamed complex types
 
 The following XML schema complex types have been renamed:
 
@@ -56,7 +58,7 @@ The following XML schema complex types have been renamed:
 | `WatchDogs` | `Watchdogs`
 |====
 
-==== Replaced the `Status` type with enum types
+=== Replaced the `Status` type with enum types
 
 Currently the status of different objects is reported using the `Status`
 type, which contains a `state` string describing the status and another
@@ -91,7 +93,7 @@ the status of the same virtual machine will now be reported as follows:
 </vm>
 ----
 
-==== Remove the NIC `network` and `port_mirroring` properties
+=== Remove the NIC `network` and `port_mirroring` properties
 
 The NIC `network` and `port_mirroring` elements have been replaced by
 the `vnic_profile` element, so when creating or updating a NIC instead
@@ -131,22 +133,22 @@ Note that the `network` element hasn't been removed from the XML schema
 because it is still used by the `initialization` element, but it will be
 completely ignored if provided when creating or updating a NIC.
 
-==== Remove the NIC `active` property
+=== Remove the NIC `active` property
 
 The NIC `active` property was replaced by `plugged` some time ago. It
 has been completely removed now.
 
-==== Remove the disk `type` property
+=== Remove the disk `type` property
 
 The `type` property of disks has been removed, but kept in the XML
 schema and ignored. It has been completely removed now.
 
-==== Remove the disk `size` property
+=== Remove the disk `size` property
 
 The disk `size` property has been replaced by `provisioned_size` long
 ago. It has been completely removed now.
 
-==== Removed support for pinning a VM to a single host
+=== Removed support for pinning a VM to a single host
 
 Before version 3.6 the API had the possibility to pin a VM to a single
 host, using the `placement_policy` element of the VM entity:
@@ -188,7 +190,7 @@ To preserve backwards compatibility the single `host` element was
 preserved. In 4.0 this has been removed, so applications will need to
 use the `hosts` element even if when pinning to a single host.
 
-==== Removed the `capabilities.permits` element
+=== Removed the `capabilities.permits` element
 
 The list of permits is potentiall different for each cluster level, and
 it has been added to the `version` element long ago, but it has been
@@ -220,13 +222,13 @@ that cluster level, in particular the set of supported permits:
 </cluster_level>
 ----
 
-==== Removed the `storage_manager` element
+=== Removed the `storage_manager` element
 
 The `storage_manager` element was replaced by the `spm` element some
 time ago. The old one was kept for backwards compatibility, but it has
 been completely removed now.
 
-==== Removed the data center `storage_type` element
+=== Removed the data center `storage_type` element
 
 Data centers used to be associated to a specific storage type (NFS,
 Fiber Channel, iSCSI, etc) but they have been changed some time so that
@@ -235,7 +237,7 @@ new `local` element was introduced to indicate this, and the old
 `storage_type` was element was preserved for backwards compatibility.
 This old element has now been completely removed.
 
-==== Remove the `timezone` element
+=== Remove the `timezone` element
 
 The VM resource used to contain a `timezone` element to represent the
 time zone. This element only allowed a string:
@@ -263,7 +265,7 @@ offset, it was replaced with a new structured `time_zone` element:
 The old `timezone` element was preserved, but it has been completely
 removed now.
 
-==== Removed the `guest_info` element
+=== Removed the `guest_info` element
 
 The `guest_info` element was used to hold information gathered by the
 guest agent, like the IP addresses and the fully qualified host name.
@@ -332,7 +334,7 @@ GET /ovirt-engine/api/vms/123
 This will contain the same information that `guest_info.fqdn` used to
 contain.
 
-==== Replaced CPU `id` attribute with `type` element
+=== Replaced CPU `id` attribute with `type` element
 
 The `cpu` element used to have an `id` attribute that indicates the type
 of CPU:
@@ -357,7 +359,7 @@ attribute has been replaced with a new `type` element:
 </cpu>
 ----
 
-==== Use elements instead of attributes in CPU topology
+=== Use elements instead of attributes in CPU topology
 
 In the past the CPU topology element used attributes for its properties:
 
@@ -384,7 +386,7 @@ replaced by inner elements:
 </cpu>
 ----
 
-==== Use elements instead of attributes in VCPU pin
+=== Use elements instead of attributes in VCPU pin
 
 In the past the VCPU pin element used attributes for its properties:
 
@@ -408,7 +410,7 @@ replaced by inner elements:
 </cpu_tune>
 ----
 
-==== Use elements instead of attributes in VCPU pin
+=== Use elements instead of attributes in VCPU pin
 
 In the past the `version` element used attributes for its properties:
 
@@ -429,7 +431,7 @@ replaced by inner elements:
 </version>
 ----
 
-==== Use elements instead of attributes in memory overcommit
+=== Use elements instead of attributes in memory overcommit
 
 In the past the `overcommit` element used attributes for its properties:
 
@@ -454,7 +456,7 @@ replaced by inner elements:
 </memory_policy>
 ----
 
-==== Use elements instead of attributes in `console`
+=== Use elements instead of attributes in `console`
 
 In the past the `console` element used attributes for its properties:
 
@@ -473,7 +475,7 @@ replaced by inner elements:
 </console>
 ----
 
-==== Use elements instead of attributes in VIRTIO SCSI
+=== Use elements instead of attributes in VIRTIO SCSI
 
 In the past the VIRTIO ISCSI element used attributes for its properties:
 
@@ -492,7 +494,7 @@ replaced by inner elements:
 </virtio_scsi>
 ----
 
-==== Use element instead of attribute for power management agent `type`
+=== Use element instead of attribute for power management agent `type`
 
 The power management `type` property was represented as an attribute:
 
@@ -516,7 +518,7 @@ replaced with an inner element:
 </agent>
 ----
 
-==== Use elements instead of attributes in power management agent options
+=== Use elements instead of attributes in power management agent options
 
 In the past the power management agent options element used attributes
 for its properties:
@@ -548,7 +550,7 @@ replaced with inner elements:
 </options>
 ----
 
-==== Use elements instead of attributes in IP address:
+=== Use elements instead of attributes in IP address:
 
 In the past the IP address element used attributes for its properties:
 
@@ -568,7 +570,7 @@ replaced with inner elements:
 </ip>
 ----
 
-==== Use elements instead of attributes in MAC address:
+=== Use elements instead of attributes in MAC address:
 
 In the past the MAC address element used attributes for its properties:
 
@@ -587,7 +589,7 @@ replaced by inner elements:
 </mac>
 ----
 
-==== Use elements instead of attributes in boot device:
+=== Use elements instead of attributes in boot device:
 
 In the past the boot device element used attributes for its properties:
 
@@ -606,7 +608,7 @@ replaced by inner elements:
 </boot>
 ----
 
-==== Use element instead of attribute for operating system `type`
+=== Use element instead of attribute for operating system `type`
 
 The operating system `type` property was represented as an attribute:
 
@@ -628,7 +630,7 @@ replaced with an inner element:
 </os>
 ----
 
-==== Removed the `force` parameter from the request to retrieve a host
+=== Removed the `force` parameter from the request to retrieve a host
 
 The request to retrieve a host used to support a `force` matrix
 parameter to indicate that the data of the host should be refreshed
@@ -659,7 +661,7 @@ And then one to retrieve it, without the `force` parameter:
 GET /ovirt-engine/api/hosts/123
 ....
 
-==== Removed deprecated host power management configuration
+=== Removed deprecated host power management configuration
 
 The host power management configuration used to be part of the host
 resource, using embedded configuration elements:
@@ -687,7 +689,7 @@ were preserved for backwards compatibility. All these elements have been
 completely removed, so the only way to query or modify the power management
 agents is now the `/hosts/123/fenceagents` sub-collection.
 
-==== Use multiple `boot.devices.device` instead of multiple `boot`
+=== Use multiple `boot.devices.device` instead of multiple `boot`
 
 In the past the way to specify the boot sequence when starting a virtual
 machine was to use multiple `boot` elements, each containing a `dev`
@@ -740,7 +742,7 @@ POST /ovirt-engine/api/vms/123/start
 </action>
 ----
 
-==== Removed the `disks.clone` and `disks.detach_only` elements
+=== Removed the `disks.clone` and `disks.detach_only` elements
 
 These elements aren't really part of the representation of disks, but
 parameters of the operations to add and remove virtual machines.
@@ -801,14 +803,14 @@ parameter:
 DELETE /ovirt-engine/api/vms/123?detach_only=true
 ....
 
-==== Rename element `vmpool` to `vm_pool`
+=== Rename element `vmpool` to `vm_pool`
 
 The names of the elements that represent pools of virtual machines used
 to be `vmpool` and `vmpools`. They have been renamed to `vm_pool` and
 `vm_pools` in order to have a consistent correspondence between names of
 complex types (`VmPool` and `VmPools` in this case) and elements.
 
-==== Use `logical_units` instead of multiple `logical_unit`
+=== Use `logical_units` instead of multiple `logical_unit`
 
 The logical units that are part of a volume group used to be reported as
 an unbounded number of `logical_unit` elements. For example, when
@@ -866,7 +868,7 @@ GET /ovirt-engine/api/storagedomains/123
 </storage_domain>
 ----
 
-==== Removed the `snapshots.collapse_snapshots` element
+=== Removed the `snapshots.collapse_snapshots` element
 
 This element isn't really part of the representation of snapshots, but
 a parameter of the operation that imports a virtual machine from an
@@ -899,7 +901,7 @@ POST /ovirt-engine/api/storagedomains/123/vms/456/import?collapse_snapshots=true
 <action/>
 ----
 
-==== Renamed `storage` and `host_storage` elements
+=== Renamed `storage` and `host_storage` elements
 
 The host storage collection used the `storage` and `host_storage`
 elements and the `Storage` and `HostStorage` complex types to report the
@@ -944,7 +946,7 @@ GET /ovirt-engine/api/hosts/123/storage
 </host_storage>
 ----
 
-==== Removed the `permissions.clone` element
+=== Removed the `permissions.clone` element
 
 This element isn't really part of the representation of permissions, but
 a parameter of the operations to create virtual machines or templates:
@@ -1004,7 +1006,7 @@ POST /ovirt-engine/api/templates?clone_permissions=true
 </template>
 ----
 
-==== Renamed the random number generator `source` elements
+=== Renamed the random number generator `source` elements
 
 The random number generator sources used to be reported using a
 collection of `source` elements wrapped by an element with a name
@@ -1089,7 +1091,7 @@ GET /ovirt-engine/api/hosts/123
 Note the use of `required_rng_source` and `supported_rng_source` instead
 of just `source`.
 
-==== Removed the intermediate `tag.parent` element
+=== Removed the intermediate `tag.parent` element
 
 The relationship bettween a tag and it's parent tag used to be
 represented using an intermedite `parent` tag, that in turn contains
@@ -1116,7 +1118,7 @@ used now:
 </tag>
 ----
 
-==== Remove scheduling built-in names and thresholds
+=== Remove scheduling built-in names and thresholds
 
 In the past the specification of scheduling policies for clusters was
 based in built-in names and thresholds. For example a cluster that used
@@ -1191,7 +1193,7 @@ GET /ovirt-engine/api/clusters/123
 
 When creating or updating a cluster only the `id` will be accepted.
 
-==== Removed the `bricks.replica_count` and `bricks.stripe_count` elements
+=== Removed the `bricks.replica_count` and `bricks.stripe_count` elements
 
 These elements aren't really part of the representation of a collection of
 bricks, but parameters of the operations to add and remove bricks. They have
@@ -1206,7 +1208,7 @@ POST .../bricks?replica_count=3&stripe_count=2
 DELETE .../bricks?replica_count=3
 ....
 
-==== Renamed the statistics `type` property to `kind`
+=== Renamed the statistics `type` property to `kind`
 
 The statistics used to be represented using a `type` element that indicates the
 kind of statistic (gauge, counter, etc) and also a `type` attribute that
@@ -1240,7 +1242,7 @@ replaced by `kind`, and both `kind` and `type` are now elements:
 </statistic>
 ----
 
-==== Use multiple `vcpu_pins.vcpu_pin` instead of multiple `vcpu_pin`
+=== Use multiple `vcpu_pins.vcpu_pin` instead of multiple `vcpu_pin`
 
 In the past the way to specify the virtual to physical CPU pinning of a virtual
 machine was to use multiple `vcpu_pin` elements:
@@ -1276,7 +1278,7 @@ been changed to use a wrapper element, in this case `vcpu_pins`:
 </vm>
 ----
 
-==== Use `force` parameter to force remove a data center
+=== Use `force` parameter to force remove a data center
 
 The operation that removes a data center supports a `force` parameter.  In
 order to use it the `DELETE` operation used to support an optional action
@@ -1299,7 +1301,7 @@ This optional action parameter has been replaced with an optional parameter:
 DELETE /ovirt-engine/api/datacenters/123?force=true
 ....
 
-==== Use `force` parameter to force remove a host
+=== Use `force` parameter to force remove a host
 
 The operation that removes a host supports a `force` parameter. In order to use
 it the `DELETE` operation used to support an optional action parameter:
@@ -1321,7 +1323,7 @@ This optional action parameter has been replaced with an optional parameter:
 DELETE /ovirt-engine/api/host/123?force=true
 ....
 
-==== Use parameters for force remove storage domain
+=== Use parameters for force remove storage domain
 
 The operation that removes a storage domain supports the `force`, `destroy` and
 `host` parameters. These parameters were passed to the `DELETE` method using
@@ -1361,7 +1363,7 @@ To delete with the `destroy` parameter:
 DELETE /ovirt-engine/api/storagedomain/123?host=myhost&destroy=true
 ....
 
-==== Use `host` parameter to remove storage server connection
+=== Use `host` parameter to remove storage server connection
 
 The operation that removes a storage server connection supports a `host`
 parameter. In order to use it the `DELETE` method used to support an optional
@@ -1386,7 +1388,7 @@ This optional action parameter has been replaced with an optional parameter:
 DELETE /ovirt-engine/api/storageconnections/123?host=myhost
 ....
 
-==== Use `force` and `storage_domain` parameters to remove template disks
+=== Use `force` and `storage_domain` parameters to remove template disks
 
 The operation that removes a template disk supports the `force` and
 `storage_domain` parameters. In order to use it them the `DELETE` method used
@@ -1416,7 +1418,7 @@ DELETE /ovirt-engine/api/templates/123/disksattachments/456?force=true
 DELETE /ovirt-engine/api/templates/123/disksattachments/456?storage_domain=123
 ....
 
-==== Don't remove disks via the VM disk API
+=== Don't remove disks via the VM disk API
 
 Removing an entity by deleting `/vms/123/disks/456` means removing the
 relationship between the VM and the disk - i.e., this operation should just
@@ -1429,7 +1431,7 @@ unreverseable consequences. To remove a disk, instead use the
 DELETE /ovirt-engine/api/disks/456
 ....
 
-==== Use `force` query parameter to force remove a virtual machine
+=== Use `force` query parameter to force remove a virtual machine
 
 The operation that removes a virtual machine supports a `force` parameter. In
 order to use it the `DELETE` method used to support an optional action
@@ -1453,7 +1455,7 @@ parameter:
 DELETE /ovirt-engine/api/vms/123?force=true
 ....
 
-==== Use `POST` instead of `DELETE` to remove multiple bricks
+=== Use `POST` instead of `DELETE` to remove multiple bricks
 
 The operation that removes multiple Gluster bricks was implemented using the
 `DELETE` method and passing the list of bricks as the body of the request:
@@ -1487,7 +1489,7 @@ POST /ovirt-engine/api/clusters/123/glustervolumes/456/bricks/remove
 </bricks>
 ----
 
-==== Removed the `scheduling_policy.policy` element
+=== Removed the `scheduling_policy.policy` element
 
 The element was kept for backward compatibility. Use `scheduling_policy.name`
 instead.
@@ -1518,7 +1520,7 @@ PUT /ovirt-engine/api/schedulingpolicies/123
 </scheduling_policy>
 ----
 
-==== Added `snapshot.snapshot_type`
+=== Added `snapshot.snapshot_type`
 
 Enums are being gradually introduces to the API. Some fields which were string
 until now, are replaced with an appropriate enum. One such field is vm.type.
@@ -1535,12 +1537,12 @@ type. So a new field has been added to snapshot entity:
 </snapshot>
 ----
 
-==== Removed `move` action from `VM`
+=== Removed `move` action from `VM`
 
 The deprecated `move` action of the `VM` entity has been removed.  Instead, you
 can move inidividual disks.
 
-==== Moved `reported_configurations.in_sync` to `network_attachment`
+=== Moved `reported_configurations.in_sync` to `network_attachment`
 
 In version 3 of the API the XML schema type `ReportedConfigurations` had a
 `in_sync` property:
@@ -1576,7 +1578,7 @@ enclosing `network_attachment`:
 </network_attachment>
 ----
 
-==== Replaced `capabilities` with `clusterlevels`
+=== Replaced `capabilities` with `clusterlevels`
 
 The top level `capabilities` collection has been replaced by the new
 `clusterlevels` collection. This new collection will contain the information
@@ -1631,7 +1633,7 @@ This will return the details of that version:
 </cluster_level>
 ----
 
-==== Replaced `disks` with `diskattachments`
+=== Replaced `disks` with `diskattachments`
 
 In version 3 of the API virtual machines and templates had a `disks` collection
 containing all the information of the disks attached to them.  In version 4 of
@@ -1731,7 +1733,7 @@ specific storage domains will now look like this:
 </template>
 ----
 
-==== Use `iscsi_targets` element to discover unregistered storage
+=== Use `iscsi_targets` element to discover unregistered storage
 
 In version 3 of the API the operation to discover unregistered storage domains
 used to receive a list of iSCSI targets, using multiple `iscsi_target`
@@ -1773,7 +1775,6 @@ POST /ovirt-engine/api/hosts/123/unregisteredstoragedomaindiscover
 </action>
 ----
 
-=== Changes in Engine version 4.5
+== Changes in Engine version 4.5
 
-==== Openstack Volume (Cinder) integration replaced by Managed Block Storage.
-
+=== Openstack Volume (Cinder) integration replaced by Managed Block Storage.


### PR DESCRIPTION
Updating Asciidoc cross-refs and some tags in the top level .adoc files.
Fixed header levels to comply with current Asciidoc formatting conventions.