### PR TITLE
Introduce isolate threads CpuPinningPolicy

### DIFF
--- a/src/main/java/types/CpuPinningPolicy.java
+++ b/src/main/java/types/CpuPinningPolicy.java
@@ -81,6 +81,18 @@ public enum CpuPinningPolicy {
      * @status added
      * @since 4.5
      */
-    DEDICATED;
+    DEDICATED,
+
+    /**
+     * The CPU pinning will be automatically calculated by the engine when a vm starts, and it will be dropped when the vm stops.
+     *
+     * The pinning is exclusive, each virtual thread will get an exclusive physical core. That means that no other VM can use the pinned physical CPU.
+     *
+     * @author Liran Rotenberg <lrotenbe@redhat.com>
+     * @date 13 Apr 2021
+     * @status added
+     * @since 4.5.1
+     */
+    ISOLATE_THREADS;
 }
 


### PR DESCRIPTION
This patch introduces the new isolate threads policy.
It acts as dedicated policy, but each virtual CPU (a virtual thread)
will get a physical core to itself.

Change-Id: Iededc6e18b536889cf2da5dcc9a3c6dcb554a268
Bug-Url: https://bugzilla.redhat.com/1782077
Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>