### PR TITLE
copr: allow to build src.rpm in fc35 buildroot

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,7 +1,7 @@
 .PHONY: installdeps srpm
 
 installdeps:
-	dnf -y install git gzip java-11-openjdk-devel make maven ovirt-engine-api-metamodel rpm-build sed unzip
+	dnf -y install git gzip java-11-openjdk-devel make maven rpm-build sed unzip
 
 srpm: installdeps
 	./.automation/build-srpm.sh exported-artifacts 1

--- a/ovirt-engine-api-model.spec.in
+++ b/ovirt-engine-api-model.spec.in
@@ -12,7 +12,10 @@ BuildArch:	noarch
 
 BuildRequires:  java-11-openjdk-devel
 BuildRequires:  maven-local
+%if 0%{?rhel} >= 8
+# Not supporting fedora, but need to build src.rpm there for copr.
 BuildRequires:  ovirt-engine-api-metamodel
+%endif
 BuildRequires:  mvn(org.apache.maven.plugin-tools:maven-plugin-annotations)
 BuildRequires:  mvn(org.apache.maven.plugins:maven-antrun-plugin)
 BuildRequires:  mvn(org.apache.maven.plugins:maven-compiler-plugin)


### PR DESCRIPTION
Dropping missing packages in f35 build root allowing to build on copr.

Signed-off-by: Sandro Bonazzola <<sbonazzo@redhat.com>>