### PR TITLE
Updating 2 anchor IDs to eliminate duplication

### DIFF
--- a/src/main/java/003-CommonConcepts.adoc
+++ b/src/main/java/003-CommonConcepts.adoc
@@ -2,7 +2,7 @@
 [id="common-concepts"]
 = Common concepts
 
-[id="types"]
+[id="types-concept"]
 == Types
 
 The API uses the _type_ concept to describe the different kinds of objects
@@ -172,7 +172,7 @@ a collection of virtual machines appears as follows:
 }
 ----
 
-[id="services"]
+[id="services-concept"]
 == Services
 
 Services are the parts of the server responsible for retrieving, adding


### PR DESCRIPTION
Sandro removed 2 IDs in https://github.com/oVirt/ovirt-site/pull/2885.
This PR fixes the problem of duplicate anchor IDs in the generated model.adoc file.