### PR TITLE
networking - fix typo in port mirroring limitations

### DIFF
--- a/src/main/java/types/VnicProfile.java
+++ b/src/main/java/types/VnicProfile.java
@@ -43,7 +43,7 @@ public interface VnicProfile extends Identified {
      *
      * Port mirroring has the following limitations:
      *
-     *  - Hot plugging a NIC with a vNIC profile that has port mirroring enabled is not supported.
+     *  - Hot linking a NIC with a vNIC profile that has port mirroring enabled is not supported.
      *  - Port mirroring cannot be altered when the vNIC profile is attached to a virtual machine.
      *
      * Given the above limitations, it is recommended that you enable port mirroring on an additional,


### PR DESCRIPTION
Hot linking vNICs with a profile that has port mirroring enabled is not
supported, and not hot plugging.

Change-Id: I371ad695674a63499e63b18ba771a25fb0df8afc
Signed-off-by: Eitan Raviv <eraviv@redhat.com>