### PR TITLE
Update build instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -328,7 +328,7 @@ Open it with your browser and check your changes.
 To build this project use the usual Maven command line:
 
 ```sh
-$ mvn clean install
+$ mvn clean install -Pgenerate-adoc-html
 ```
 
 ## Releasing


### PR DESCRIPTION
In order to be able to compile ovirt-engine, model-*-javadoc.jar must
be present.  But it’s built and installed only with generate-adoc-html
profile now.  Let’s update the build instructions accordingly.