### PR TITLE
spec: drop deps on asciidoctor

### DIFF
--- a/ovirt-engine-api-model.spec.in
+++ b/ovirt-engine-api-model.spec.in
@@ -23,8 +23,6 @@ BuildRequires:	mvn(org.apache.maven.plugins:maven-antrun-plugin)
 BuildRequires:	mvn(org.apache.maven.plugins:maven-compiler-plugin)
 BuildRequires:	mvn(org.apache.maven.plugins:maven-source-plugin)
 BuildRequires:	mvn(org.apache.maven.plugins:maven-surefire-plugin)
-BuildRequires:	mvn(org.asciidoctor:asciidoctorj)
-BuildRequires:	mvn(org.asciidoctor:asciidoctor-maven-plugin)
 BuildRequires:	mvn(org.codehaus.mojo:exec-maven-plugin)
 BuildRequires:	mvn(org.ovirt.maven.plugins:ovirt-jboss-modules-maven-plugin)
 


### PR DESCRIPTION
docs generation is performed before generating the src.rpm
so there's no need to require those deps for rpm build.

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>