### PR TITLE
Fixing duplicate ID, removing assembly content tag

### DIFF
--- a/src/main/java/002-AuthenticationAndSecurity.adoc
+++ b/src/main/java/002-AuthenticationAndSecurity.adoc
@@ -1,4 +1,3 @@
-:_content-type: ASSEMBLY
 [id="authentication-and-security"]
 = Authentication and Security
 

--- a/src/main/java/003-CommonConcepts.adoc
+++ b/src/main/java/003-CommonConcepts.adoc
@@ -1,4 +1,3 @@
-:_content-type: ASSEMBLY
 [id="common-concepts"]
 = Common concepts
 

--- a/src/main/java/004-QuickStartExample.adoc
+++ b/src/main/java/004-QuickStartExample.adoc
@@ -1,4 +1,3 @@
-:_content-type: ASSEMBLY
 [id="quick-start-examples"]
 = Quick Start Examples
 

--- a/src/main/java/A01-PrimitiveTypes.adoc
+++ b/src/main/java/A01-PrimitiveTypes.adoc
@@ -1,5 +1,4 @@
 [appendix]
-:_content-type: ASSEMBLY
 [id="primitive-types"]
 = Primitive types
 

--- a/src/main/java/A02-ChangesInV4.adoc
+++ b/src/main/java/A02-ChangesInV4.adoc
@@ -1,5 +1,4 @@
 [appendix]
-:_content-type: ASSEMBLY
 [id="changes-in-version-4-of-the-api"]
 = Changes in version 4 of the API
 
@@ -402,7 +401,7 @@ replaced by inner elements:
 </cpu>
 ----
 
-[id="use-elements-instead-of-attributes-in-vcpu-pin"]
+[id="use-elements-instead-of-attributes-in-vcpu-pin-2"]
 === Use elements instead of attributes in VCPU pin
 
 In the past the VCPU pin element used attributes for its properties:
@@ -427,7 +426,7 @@ replaced by inner elements:
 </cpu_tune>
 ----
 
-[id="use-elements-instead-of-attributes-in-vcpu-pin"]
+[id="use-elements-instead-of-attributes-in-vcpu-pin-1"]
 === Use elements instead of attributes in VCPU pin
 
 In the past the `version` element used attributes for its properties:


### PR DESCRIPTION
Changes:

- Changed duplicate anchor IDs that were breaking the Asciidoc build

- Removed "assembly" content tag from 002 and later parts because the asciidoc files are used to generate a single file. So only the first "assembly" tag needs to appear.

@oliel Please review. 