### PR TITLE
Replace slashes in xrefs with hyphens

### DIFF
--- a/src/main/java/services/AttachedStorageDomainDiskService.java
+++ b/src/main/java/services/AttachedStorageDomainDiskService.java
@@ -29,8 +29,8 @@ import types.StorageDomain;
  *
  * IMPORTANT: Since version 4.2 of the engine this service is intended only to list disks available in the storage
  * domain, and to register unregistered disks. All the other operations, like copying a disk, moving a disk, etc, have
- * been deprecated and will be removed in the future. To perform those operations use the xref:services/disks[service that manages all the disks of the system]
- * or the xref:services/disk[service that manages a specific disk].
+ * been deprecated and will be removed in the future. To perform those operations use the xref:services-disks[service that manages all the disks of the system]
+ * or the xref:services-disk[service that manages a specific disk].
  *
  * @author Juan Hernandez <juan.hernandez@redhat.com>
  * @date 4 Nov 2016
@@ -43,7 +43,7 @@ public interface AttachedStorageDomainDiskService extends MeasurableService {
      * Copies a disk to the specified storage domain.
      *
      * IMPORTANT: Since version 4.2 of the engine this operation is deprecated, and preserved only for backwards
-     * compatibility. It will be removed in the future. To copy a disk use the xref:services/disk/methods/copy[copy]
+     * compatibility. It will be removed in the future. To copy a disk use the xref:services-disk-methods-copy[copy]
      * operation of the service that manages that disk.
      *
      * @author Juan Hernandez <juan.hernandez@redhat.com>
@@ -76,7 +76,7 @@ public interface AttachedStorageDomainDiskService extends MeasurableService {
      *
      * IMPORTANT: Since version 4.2 of the engine this operation is deprecated, and preserved only for backwards
      * compatibility. It will be removed in the future. To update a disk use the
-     * xref:services/disk/methods/update[update] operation of the service that manages that disk.
+     * xref:services-disk-methods-update[update] operation of the service that manages that disk.
      *
      * @author Juan Hernandez <juan.hernandez@redhat.com>
      * @date 4 Jan 2017
@@ -98,7 +98,7 @@ public interface AttachedStorageDomainDiskService extends MeasurableService {
      * Exports a disk to an export storage domain.
      *
      * IMPORTANT: Since version 4.2 of the engine this operation is deprecated, and preserved only for backwards
-     * compatibility. It will be removed in the future. To export a disk use the xref:services/disk/methods/export[export]
+     * compatibility. It will be removed in the future. To export a disk use the xref:services-disk-methods-export[export]
      * operation of the service that manages that disk.
      *
      * @author Juan Hernandez <juan.hernandez@redhat.com>
@@ -138,7 +138,7 @@ public interface AttachedStorageDomainDiskService extends MeasurableService {
      * Moves a disk to another storage domain.
      *
      * IMPORTANT: Since version 4.2 of the engine this operation is deprecated, and preserved only for backwards
-     * compatibility. It will be removed in the future. To move a disk use the xref:services/disk/methods/move[move]
+     * compatibility. It will be removed in the future. To move a disk use the xref:services-disk-methods-move[move]
      * operation of the service that manages that disk.
      *
      * @author Juan Hernandez <juan.hernandez@redhat.com>
@@ -170,7 +170,7 @@ public interface AttachedStorageDomainDiskService extends MeasurableService {
      * Removes a disk.
      *
      * IMPORTANT: Since version 4.2 of the engine this operation is deprecated, and preserved only for backwards
-     * compatibility. It will be removed in the future. To remove a disk use the xref:services/disk/methods/remove[remove]
+     * compatibility. It will be removed in the future. To remove a disk use the xref:services-disk-methods-remove[remove]
      * operation of the service that manages that disk.
      *
      * @author Juan Hernandez <juan.hernandez@redhat.com>
@@ -184,7 +184,7 @@ public interface AttachedStorageDomainDiskService extends MeasurableService {
      * Sparsify the disk.
      *
      * IMPORTANT: Since version 4.2 of the engine this operation is deprecated, and preserved only for backwards
-     * compatibility. It will be removed in the future. To remove a disk use the xref:services/disk/methods/remove[remove]
+     * compatibility. It will be removed in the future. To remove a disk use the xref:services-disk-methods-remove[remove]
      * operation of the service that manages that disk.
      *
      * @author Juan Hernandez <juan.hernandez@redhat.com>

--- a/src/main/java/services/AttachedStorageDomainDisksService.java
+++ b/src/main/java/services/AttachedStorageDomainDisksService.java
@@ -37,9 +37,9 @@ public interface AttachedStorageDomainDisksService {
      * Adds or registers a disk.
      *
      * IMPORTANT: Since version 4.2 of the engine this operation is deprecated, and preserved only for backwards
-     * compatibility. It will be removed in the future. To add a new disk use the xref:services/disks/methods/add[add]
+     * compatibility. It will be removed in the future. To add a new disk use the xref:services-disks-methods-add[add]
      * operation of the service that manages the disks of the system. To register an unregistered disk use the
-     * xref:services/attached_storage_domain_disk/methods/register[register] operation of the service that manages
+     * xref:services-attached_storage_domain_disk-methods-register[register] operation of the service that manages
      * that disk.
      *
      * @author Juan Hernandez <juan.hernandez@redhat.com>

--- a/src/main/java/services/ClusterEnabledFeatureService.java
+++ b/src/main/java/services/ClusterEnabledFeatureService.java
@@ -42,7 +42,7 @@ public interface ClusterEnabledFeatureService {
      * GET /ovirt-engine/api/clusters/123/enabledfeatures/456
      * ----
      *
-     * That will return a xref:types/cluster_feature[ClusterFeature] object containing the name:
+     * That will return a xref:types-cluster_feature[ClusterFeature] object containing the name:
      *
      * [source,xml]
      * ----

--- a/src/main/java/services/ClusterFeatureService.java
+++ b/src/main/java/services/ClusterFeatureService.java
@@ -42,7 +42,7 @@ public interface ClusterFeatureService {
      * GET /ovirt-engine/api/clusterlevels/4.1/clusterfeatures/456
      * ----
      *
-     * That will return a xref:types/cluster_feature[ClusterFeature] object containing the name:
+     * That will return a xref:types-cluster_feature[ClusterFeature] object containing the name:
      *
      * [source,xml]
      * ----

--- a/src/main/java/services/ClusterLevelService.java
+++ b/src/main/java/services/ClusterLevelService.java
@@ -23,7 +23,7 @@ import org.ovirt.api.metamodel.annotations.Service;
 import types.ClusterLevel;
 
 /**
- * Provides information about a specific cluster level. See the xref:services/cluster_levels[ClusterLevels] service for
+ * Provides information about a specific cluster level. See the xref:services-cluster_levels[ClusterLevels] service for
  * more information.
  */
 @Service
@@ -38,7 +38,7 @@ public interface ClusterLevelService {
      * GET /ovirt-engine/api/clusterlevels/3.6
      * ----
      *
-     * That will return a xref:types/cluster_level[ClusterLevel] object containing the supported CPU types, and other
+     * That will return a xref:types-cluster_level[ClusterLevel] object containing the supported CPU types, and other
      * information which describes the cluster level:
      *
      * [source,xml]

--- a/src/main/java/services/DiskAttachmentsService.java
+++ b/src/main/java/services/DiskAttachmentsService.java
@@ -29,7 +29,7 @@ import static org.ovirt.api.metamodel.language.ApiLanguage.mandatory;
 
 /**
  * This service manages the set of disks attached to a virtual machine. Each attached disk is represented by a
- * xref:types/disk_attachment[DiskAttachment], containing the bootable flag, the disk interface and the reference to
+ * xref:types-disk_attachment[DiskAttachment], containing the bootable flag, the disk interface and the reference to
  * the disk.
  */
 @Service

--- a/src/main/java/services/DiskService.java
+++ b/src/main/java/services/DiskService.java
@@ -487,7 +487,7 @@ public interface DiskService extends MeasurableService {
      * Refreshing a direct LUN disk is useful when:
      *
      * - The LUN was added using the API without the host parameter, and therefore does not contain
-     *   any information from the storage (see xref:services/disks/methods/add[DisksService::add]).
+     *   any information from the storage (see xref:services-disks-methods-add[DisksService::add]).
      * - New information about the LUN is available on the storage and you want to update the LUN with it.
      *
      * To refresh direct LUN disk `123` using host `456`, send the following request:

--- a/src/main/java/services/DisksService.java
+++ b/src/main/java/services/DisksService.java
@@ -46,10 +46,10 @@ public interface DisksService {
      *
      * *Adding a new image disk:*
      *
-     * When creating a new floating image xref:types/disk[Disk], the API requires the `storage_domain`, `provisioned_size`
+     * When creating a new floating image xref:types-disk[Disk], the API requires the `storage_domain`, `provisioned_size`
      * and `format` attributes.
      *
-     * Note that block storage domains (i.e. storage domains with the xref:types/storage_type[storage type] of iSCSI or
+     * Note that block storage domains (i.e. storage domains with the xref:types-storage_type[storage type] of iSCSI or
      * FCP) don't support the combination of the raw `format` with `sparse=true`, so `sparse=false` must be stated
      * explicitly.
      *

--- a/src/main/java/services/ExternalTemplateImportsService.java
+++ b/src/main/java/services/ExternalTemplateImportsService.java
@@ -46,7 +46,7 @@ public interface ExternalTemplateImportsService {
      * POST /externaltemplateimports
      * ----
      *
-     * With request body of type xref:types/external_template_import[ExternalTemplateImport], for example:
+     * With request body of type xref:types-external_template_import[ExternalTemplateImport], for example:
      *
      * [source,xml]
      * ----

--- a/src/main/java/services/ExternalVmImportsService.java
+++ b/src/main/java/services/ExternalVmImportsService.java
@@ -45,7 +45,7 @@ public interface ExternalVmImportsService {
      * POST /externalvmimports
      * ----
      *
-     * With request body of type xref:types/external_vm_import[ExternalVmImport], for example:
+     * With request body of type xref:types-external_vm_import[ExternalVmImport], for example:
      *
      * [source,xml]
      * ----

--- a/src/main/java/services/HostService.java
+++ b/src/main/java/services/HostService.java
@@ -192,10 +192,10 @@ public interface HostService extends MeasurableService {
      * ----
      *
      * IMPORTANT: Since {engine-name} 4.3, it is possible to also specify `commit_on_success` in
-     * the xref:services/host/methods/setup_networks[setupnetworks] request, in which case the new
+     * the xref:services-host-methods-setup_networks[setupnetworks] request, in which case the new
      * configuration is automatically saved in the {hypervisor-name} upon completing the setup and
      * re-establishing connectivity between the {hypervisor-name} and {engine-name}, and without
-     * waiting for a separate xref:services/host/methods/commit_net_config[commitnetconfig] request.
+     * waiting for a separate xref:services-host-methods-commit_net_config[commitnetconfig] request.
      *
      * @author Juan Hernandez <juan.hernandez@redhat.com>
      * @author Martin Mucha <mmucha@redhat.com>
@@ -1004,7 +1004,7 @@ public interface HostService extends MeasurableService {
      * Check if there are upgrades available for the host. If there are upgrades available an icon will be displayed
      * next to host status icon in the Administration Portal. Audit log messages are also added to indicate the
      * availability of upgrades. The upgrade can be started from the webadmin or by using the
-     * xref:services/host/methods/upgrade[upgrade] host action.
+     * xref:services-host-methods-upgrade[upgrade] host action.
      *
      * @author Ravi Nori <rnori@redhat.com>
      * @author Megan Lewis <melewis@redhat.com>
@@ -1246,13 +1246,13 @@ public interface HostService extends MeasurableService {
      * ----
      *
      * IMPORTANT: To make sure that the network configuration has been saved in the host, and that it will be applied
-     * when the host is rebooted, remember to call xref:services/host/methods/commit_net_config[commitnetconfig].
+     * when the host is rebooted, remember to call xref:services-host-methods-commit_net_config[commitnetconfig].
      *
      * IMPORTANT: Since {engine-name} 4.3, it is possible to also specify `commit_on_success` in
-     * the xref:services/host/methods/setup_networks[setupnetworks] request, in which case the new
+     * the xref:services-host-methods-setup_networks[setupnetworks] request, in which case the new
      * configuration is automatically saved in the {hypervisor-name} upon completing the setup and
      * re-establishing connectivity between the {hypervisor-name} and {engine-name}, and without
-     * waiting for a separate xref:services/host/methods/commit_net_config[commitnetconfig] request.
+     * waiting for a separate xref:services-host-methods-commit_net_config[commitnetconfig] request.
      *
      *
      * @author Megan Lewis <melewis@redhat.com>
@@ -1307,7 +1307,7 @@ public interface HostService extends MeasurableService {
         /**
          * Specifies whether to automatically save the configuration in the {hypervisor-name} upon completing
          * the setup and re-establishing connectivity between the {hypervisor-name} and {engine-name},
-         * and without waiting for a separate xref:services/host/methods/commit_net_config[commitnetconfig]
+         * and without waiting for a separate xref:services-host-methods-commit_net_config[commitnetconfig]
          * request.
          * The default value is `false`, which means that the configuration will not be
          * saved automatically.

--- a/src/main/java/services/ImageTransferService.java
+++ b/src/main/java/services/ImageTransferService.java
@@ -25,8 +25,8 @@ import annotations.Area;
 
 /**
  * This service provides a mechanism to control an image transfer. The client will have
- * to create a transfer by using xref:services/image_transfers/methods/add[add]
- * of the xref:services/image_transfers[image transfers] service, stating the image to transfer
+ * to create a transfer by using xref:services-image_transfers-methods-add[add]
+ * of the xref:services-image_transfers[image transfers] service, stating the image to transfer
  * data to/from.
  *
  * After doing that, the transfer is managed by this service.
@@ -65,7 +65,7 @@ import annotations.Area;
  * ----
  *
  * If the user wishes to download a disk rather than upload, he/she should specify
- * `download` as the xref:types/image_transfer_direction[direction] attribute of the transfer.
+ * `download` as the xref:types-image_transfer_direction[direction] attribute of the transfer.
  * This will grant a read permission from the image, instead of a write permission.
  *
  * E.g:
@@ -86,11 +86,11 @@ import annotations.Area;
  * Transfers have phases, which govern the flow of the upload/download.
  * A client implementing such a flow should poll/check the transfer's phase and
  * act accordingly. All the possible phases can be found in
- * xref:types/image_transfer_phase[ImageTransferPhase].
+ * xref:types-image_transfer_phase[ImageTransferPhase].
  *
- * After adding a new transfer, its phase will be xref:types/image_transfer_phase[initializing].
+ * After adding a new transfer, its phase will be xref:types-image_transfer_phase[initializing].
  * The client will have to poll on the transfer's phase until it changes.
- * When the phase becomes xref:types/image_transfer_phase[transferring],
+ * When the phase becomes xref:types-image_transfer_phase[transferring],
  * the session is ready to start the transfer.
  *
  * For example:
@@ -103,14 +103,14 @@ import annotations.Area;
  *    transfer = transfer_service.get()
  * ----
  *
- * At that stage, if the transfer's phase is xref:types/image_transfer_phase[paused_system], then the session was
+ * At that stage, if the transfer's phase is xref:types-image_transfer_phase[paused_system], then the session was
  * not successfully established. One possible reason for that is that the ovirt-imageio-daemon is not running
  * in the host that was selected for transfer.
- * The transfer can be resumed by calling xref:services/image_transfer/methods/resume[resume]
+ * The transfer can be resumed by calling xref:services-image_transfer-methods-resume[resume]
  * of the service that manages it.
  *
  * If the session was successfully established - the returned transfer entity will
- * contain the xref:types/image_transfer[transfer_url] and xref:types/image_transfer[proxy_url] attributes,
+ * contain the xref:types-image_transfer[transfer_url] and xref:types-image_transfer[proxy_url] attributes,
  * which the client needs to use in order to transfer the required data. The client can choose whatever
  * technique and tool for sending the HTTPS request with the image's data.
  *
@@ -137,7 +137,7 @@ import annotations.Area;
  *     http://ovirt.github.io/ovirt-imageio/images.html
  *
  * When finishing the transfer, the user should call
- * xref:services/image_transfer/methods/finalize[finalize]. This will make the
+ * xref:services-image_transfer-methods-finalize[finalize]. This will make the
  * final adjustments and verifications for finishing the transfer process.
  *
  * For example:
@@ -148,9 +148,9 @@ import annotations.Area;
  * ----
  *
  * In case of an error, the transfer's phase will be changed to
- * xref:types/image_transfer_phase[finished_failure], and
+ * xref:types-image_transfer_phase[finished_failure], and
  * the disk's status will be changed to `Illegal`. Otherwise it will be changed to
- * xref:types/image_transfer_phase[finished_success], and the disk will be ready
+ * xref:types-image_transfer_phase[finished_success], and the disk will be ready
  * to be used. In both cases, the transfer entity will be removed shortly after.
  *
  *

--- a/src/main/java/services/ImageTransfersService.java
+++ b/src/main/java/services/ImageTransfersService.java
@@ -30,7 +30,7 @@ import static org.ovirt.api.metamodel.language.ApiLanguage.optional;
 
 /**
  * This service manages image transfers, for performing Image I/O API in {product-name}.
- * Please refer to xref:services/image_transfer[image transfer] for further
+ * Please refer to xref:services-image_transfer[image transfer] for further
  * documentation.
  *
  * @author Amit Aviram <aaviram@redhat.com>

--- a/src/main/java/services/NetworkFiltersService.java
+++ b/src/main/java/services/NetworkFiltersService.java
@@ -27,7 +27,7 @@ import types.NetworkFilter;
  * Represents a readonly network filters sub-collection.
  *
  * The network filter enables to filter packets send to/from the VM's nic according to defined rules.
- * For more information please refer to xref:services/network_filter[NetworkFilter] service documentation
+ * For more information please refer to xref:services-network_filter[NetworkFilter] service documentation
  *
  * Network filters are supported in different versions, starting from version 3.0.
  *

--- a/src/main/java/services/NetworkService.java
+++ b/src/main/java/services/NetworkService.java
@@ -168,7 +168,7 @@ public interface NetworkService {
      * NOTE: To remove an external logical network, the network has to be removed directly from its provider by
      * link:https://developer.openstack.org/api-ref/network[OpenStack Networking API].
      * The entity representing the external network inside {product-name} is removed automatically,
-     * if xref:types/open_stack_network_provider/attributes/auto_sync[`auto_sync`] is enabled for the provider,
+     * if xref:types-open_stack_network_provider-attributes-auto_sync[`auto_sync`] is enabled for the provider,
      * otherwise the entity has to be removed using this method.
      *
      * @author Martin Mucha <mmucha@redhat.com>

--- a/src/main/java/services/PermitsService.java
+++ b/src/main/java/services/PermitsService.java
@@ -37,7 +37,7 @@ import static org.ovirt.api.metamodel.language.ApiLanguage.or;
 @Area("Infrastructure")
 public interface PermitsService {
     /**
-     * Adds a permit to the role. The permit name can be retrieved from the xref:services/cluster_levels[cluster_levels] service.
+     * Adds a permit to the role. The permit name can be retrieved from the xref:services-cluster_levels[cluster_levels] service.
      *
      * For example to assign a permit `create_vm` to the role with id `123` send a request like this:
      *

--- a/src/main/java/services/RoleService.java
+++ b/src/main/java/services/RoleService.java
@@ -86,7 +86,7 @@ public interface RoleService {
     /**
      * Updates a role. You are allowed to update `name`, `description` and `administrative` attributes after role is
      * created. Within this endpoint you can't add or remove roles permits you need to use
-     * xref:services/permits[service] that manages permits of role.
+     * xref:services-permits[service] that manages permits of role.
      *
      * For example to update role's `name`, `description` and `administrative` attributes send a request like this:
      *

--- a/src/main/java/services/SnapshotsService.java
+++ b/src/main/java/services/SnapshotsService.java
@@ -85,7 +85,7 @@ public interface SnapshotsService {
      * [IMPORTANT]
      * ====
      * When a snapshot is created, the default value for the
-     * xref:types/snapshot/attributes/persist_memorystate[persist_memorystate] attribute is `true`. That means that the content of the memory of the virtual
+     * xref:types-snapshot-attributes-persist_memorystate[persist_memorystate] attribute is `true`. That means that the content of the memory of the virtual
      * machine will be included in the snapshot, and it also means that the virtual machine will be paused
      * for a longer time. That can negatively affect applications that are very sensitive to timing (NTP
      * servers, for example). In those cases make sure that you set the attribute to `false`:

--- a/src/main/java/services/StorageDomainDiskService.java
+++ b/src/main/java/services/StorageDomainDiskService.java
@@ -30,8 +30,8 @@ import types.StorageDomain;
  * IMPORTANT: Since version 4.2 of the engine this service is intended only to list disks available in the storage
  * domain, and to register unregistered disks. All the other operations, like copying a disk, moving a disk, etc, have
  * been deprecated and will be removed in the future. To perform those operations
- * use the xref:services/disks[service that manages all the disks of the system]
- * or the xref:services/disk[service that manages a specific disk].
+ * use the xref:services-disks[service that manages all the disks of the system]
+ * or the xref:services-disk[service that manages a specific disk].
  *
  * @author Juan Hernandez <juan.hernandez@redhat.com>
  * @date 4 Nov 2016
@@ -44,7 +44,7 @@ public interface StorageDomainDiskService extends MeasurableService {
      * Copies a disk to the specified storage domain.
      *
      * IMPORTANT: Since version 4.2 of the engine this operation is deprecated, and preserved only for backwards
-     * compatibility. It will be removed in the future. To copy a disk use the xref:services/disk/methods/copy[copy]
+     * compatibility. It will be removed in the future. To copy a disk use the xref:services-disk-methods-copy[copy]
      * operation of the service that manages that disk.
      *
      * @author Juan Hernandez <juan.hernandez@redhat.com>
@@ -77,7 +77,7 @@ public interface StorageDomainDiskService extends MeasurableService {
      *
      * IMPORTANT: Since version 4.2 of the engine this operation is deprecated, and preserved only for backwards
      * compatibility. It will be removed in the future. To update a disk use the
-     * xref:services/disk/methods/update[update] operation of the service that manages that disk.
+     * xref:services-disk-methods-update[update] operation of the service that manages that disk.
      *
      * @author Juan Hernandez <juan.hernandez@redhat.com>
      * @date 4 Jan 2017
@@ -99,7 +99,7 @@ public interface StorageDomainDiskService extends MeasurableService {
      * Exports a disk to an export storage domain.
      *
      * IMPORTANT: Since version 4.2 of the engine this operation is deprecated, and preserved only for backwards
-     * compatibility. It will be removed in the future. To export a disk use the xref:services/disk/methods/export[export]
+     * compatibility. It will be removed in the future. To export a disk use the xref:services-disk-methods-export[export]
      * operation of the service that manages that disk.
      *
      * @author Juan Hernandez <juan.hernandez@redhat.com>
@@ -139,7 +139,7 @@ public interface StorageDomainDiskService extends MeasurableService {
      * Moves a disk to another storage domain.
      *
      * IMPORTANT: Since version 4.2 of the engine this operation is deprecated, and preserved only for backwards
-     * compatibility. It will be removed in the future. To move a disk use the xref:services/disk/methods/move[move]
+     * compatibility. It will be removed in the future. To move a disk use the xref:services-disk-methods-move[move]
      * operation of the service that manages that disk.
      *
      * @author Juan Hernandez <juan.hernandez@redhat.com>
@@ -171,7 +171,7 @@ public interface StorageDomainDiskService extends MeasurableService {
      * Removes a disk.
      *
      * IMPORTANT: Since version 4.2 of the engine this operation is deprecated, and preserved only for backwards
-     * compatibility. It will be removed in the future. To remove a disk use the xref:services/disk/methods/remove[remove]
+     * compatibility. It will be removed in the future. To remove a disk use the xref:services-disk-methods-remove[remove]
      * operation of the service that manages that disk.
      *
      * @author Juan Hernandez <juan.hernandez@redhat.com>
@@ -185,7 +185,7 @@ public interface StorageDomainDiskService extends MeasurableService {
      * Sparsify the disk.
      *
      * IMPORTANT: Since version 4.2 of the engine this operation is deprecated, and preserved only for backwards
-     * compatibility. It will be removed in the future. To remove a disk use the xref:services/disk/methods/remove[remove]
+     * compatibility. It will be removed in the future. To remove a disk use the xref:services-disk-methods-remove[remove]
      * operation of the service that manages that disk.
      *
      * @author Juan Hernandez <juan.hernandez@redhat.com>

--- a/src/main/java/services/StorageDomainDisksService.java
+++ b/src/main/java/services/StorageDomainDisksService.java
@@ -38,9 +38,9 @@ public interface StorageDomainDisksService {
      * Adds or registers a disk.
      *
      * IMPORTANT: Since version 4.2 of the {engine-name} this operation is deprecated, and preserved only for backwards
-     * compatibility. It will be removed in the future. To add a new disk use the xref:services/disks/methods/add[add]
+     * compatibility. It will be removed in the future. To add a new disk use the xref:services-disks-methods-add[add]
      * operation of the service that manages the disks of the system. To register an unregistered disk use the
-     * xref:services/attached_storage_domain_disk/methods/register[register] operation of the service that manages
+     * xref:services-attached_storage_domain_disk-methods-register[register] operation of the service that manages
      * that disk.
      *
      * @author Juan Hernandez <juan.hernandez@redhat.com>

--- a/src/main/java/services/StorageDomainService.java
+++ b/src/main/java/services/StorageDomainService.java
@@ -107,7 +107,7 @@ public interface StorageDomainService {
     /**
      * Updates a storage domain.
      *
-     * Not all of the xref:types/storage_domain[StorageDomain]'s attributes are updatable after creation. Those that can be
+     * Not all of the xref:types-storage_domain[StorageDomain]'s attributes are updatable after creation. Those that can be
      * updated are: `name`, `description`, `comment`, `warning_low_space_indicator`, `critical_space_action_blocker` and
      * `wipe_after_delete.` (Note that changing the `wipe_after_delete` attribute will not change the wipe after delete
      * property of disks that already exist).
@@ -294,7 +294,7 @@ public interface StorageDomainService {
      * ----
      *
      *  Note that this operation is only applicable to block storage domains (i.e., storage domains with the
-     *  xref:types/storage_type[storage type] of iSCSI or FCP).
+     *  xref:types-storage_type[storage type] of iSCSI or FCP).
      *
      * @author Liron Aravot <laravot@redhat.com>
      * @author Megan Lewis <melewis@redhat.com>

--- a/src/main/java/services/StorageDomainTemplateService.java
+++ b/src/main/java/services/StorageDomainTemplateService.java
@@ -150,7 +150,7 @@ public interface StorageDomainTemplateService {
          *
          * WARNING: Please note that this attribute has been deprecated since version 4.2.1 of the engine, and preserved only for backward
          * compatibility. It will be removed in the future. To specify `vnic_profile_mappings` use the `vnic_profile_mappings`
-         * attribute inside the xref:types/registration_configuration[RegistrationConfiguration] type.
+         * attribute inside the xref:types-registration_configuration[RegistrationConfiguration] type.
          *
          * @author Maor Lipchuk <mlipchuk@redhat.com>
          * @author Eitan Raviv <eraviv@redhat.com>

--- a/src/main/java/services/StorageDomainVmService.java
+++ b/src/main/java/services/StorageDomainVmService.java
@@ -179,7 +179,7 @@ public interface StorageDomainVmService {
          *
          * WARNING: Please note that this attribute has been deprecated since version 4.2.1 of the engine, and preserved only for backward
          * compatibility. It will be removed in the future. To specify `vnic_profile_mappings` use the `vnic_profile_mappings`
-         * attribute inside the xref:types/registration_configuration[RegistrationConfiguration] type.
+         * attribute inside the xref:types-registration_configuration[RegistrationConfiguration] type.
          *
          * @author Yevgeny Zaspitsky <yzaspits@redhat.com>
          * @author Eitan Raviv <eraviv@redhat.com>

--- a/src/main/java/services/StorageDomainVmsService.java
+++ b/src/main/java/services/StorageDomainVmsService.java
@@ -51,8 +51,8 @@ import types.Vm;
  * ----
  *
  * Virtual machines and templates in these collections have a similar representation to their counterparts in the
- * top-level xref:types/vm[Vm] and xref:types/template[Template] collections, except they also contain a
- * xref:types/storage_domain[StorageDomain] reference and an xref:services/storage_domain_vm/methods/import[import]
+ * top-level xref:types-vm[Vm] and xref:types-template[Template] collections, except they also contain a
+ * xref:types-storage_domain[StorageDomain] reference and an xref:services-storage_domain_vm-methods-import[import]
  * action.
  *
  * @author Amit Aviram <aaviram@redhat.com>

--- a/src/main/java/services/StorageDomainsService.java
+++ b/src/main/java/services/StorageDomainsService.java
@@ -43,7 +43,7 @@ public interface StorageDomainsService {
     /**
      * Adds a new storage domain.
      *
-     * Creation of a new xref:types/storage_domain[StorageDomain] requires the `name`, `type`, `host`, and `storage`
+     * Creation of a new xref:types-storage_domain[StorageDomain] requires the `name`, `type`, `host`, and `storage`
      * attributes. Identify the `host` attribute with the `id` or `name` attributes. In {product-name} 3.6 and
      * later you can enable the wipe after delete option by default on the storage domain. To configure this, specify
      * `wipe_after_delete` in the POST request. This option can be edited after the domain is created, but doing so will

--- a/src/main/java/services/TemplateDiskAttachmentsService.java
+++ b/src/main/java/services/TemplateDiskAttachmentsService.java
@@ -25,7 +25,7 @@ import types.DiskAttachment;
 
 /**
  * This service manages the set of disks attached to a template. Each attached disk is represented by a
- * xref:types/disk_attachment[DiskAttachment].
+ * xref:types-disk_attachment[DiskAttachment].
  *
  * @author Tal Nisan <tnisan@redhat.com>
  * @date 7 Jul 2016

--- a/src/main/java/services/TemplatesService.java
+++ b/src/main/java/services/TemplatesService.java
@@ -80,7 +80,7 @@ public interface TemplatesService {
      * original virtual machine. To do so use the `vm.disk_attachments` attribute, specifying the identifier of the disk
      * of the original virtual machine and the characteristics that you want to change. For example, if the original
      * virtual machine has a disk with the identifier `456`, and, for that disk, you want to change the name to `mydisk`
-     * the format to xref:types/disk_format[_Copy On Write_] and make it xref:types/disk[sparse], send a request body like
+     * the format to xref:types-disk_format[_Copy On Write_] and make it xref:types-disk[sparse], send a request body like
      * this:
      *
      * [source,xml]

--- a/src/main/java/services/VmCdromsService.java
+++ b/src/main/java/services/VmCdromsService.java
@@ -30,7 +30,7 @@ import static org.ovirt.api.metamodel.language.ApiLanguage.mandatory;
  *
  * Currently virtual machines have exactly one CDROM device. No new devices can be added, and the existing one can't
  * be removed, thus there are no `add` or `remove` methods. Changing and ejecting CDROM disks is done with the
- * xref:services/vm_cdrom/methods/update[update] method of the xref:services/vm_cdrom[service] that manages the
+ * xref:services-vm_cdrom-methods-update[update] method of the xref:services-vm_cdrom[service] that manages the
  * CDROM device.
  *
  * @author Juan Hernandez <juan.hernandez@redhat.com>

--- a/src/main/java/services/VmDiskService.java
+++ b/src/main/java/services/VmDiskService.java
@@ -81,7 +81,7 @@ public interface VmDiskService extends MeasurableService {
      * Detach the disk from the virtual machine.
      *
      * NOTE: In version 3 of the API this used to also remove the disk completely from the system, but starting with
-     * version 4 it doesn't. If you need to remove it completely use the xref:services/disk/methods/remove[remove method of the top level disk service].
+     * version 4 it doesn't. If you need to remove it completely use the xref:services-disk-methods-remove[remove method of the top level disk service].
      */
     interface Remove {
         /**

--- a/src/main/java/services/VmHostDevicesService.java
+++ b/src/main/java/services/VmHostDevicesService.java
@@ -48,7 +48,7 @@ public interface VmHostDevicesService {
      * POST /ovirt-engine/api/vms/123/hostdevices
      * ----
      *
-     * With request body of type xref:types/host_device[HostDevice], for example
+     * With request body of type xref:types-host_device[HostDevice], for example
      *
      * [source,xml]
      * ----
@@ -60,7 +60,7 @@ public interface VmHostDevicesService {
      *
      * NOTE: Attachment of a PCI device that is part of a bigger IOMMU group will result in attachment of the remaining
      * devices from that IOMMU group as "placeholders". These devices are then identified using the `placeholder`
-     * attribute of the xref:types/host_device[HostDevice] type set to `true`.
+     * attribute of the xref:types-host_device[HostDevice] type set to `true`.
      *
      * In case you want attach a device that already serves as an IOMMU placeholder, simply issue an explicit Add operation
      * for it, and its `placeholder` flag will be cleared, and the device will be accessible to the virtual machine.

--- a/src/main/java/services/VmNicService.java
+++ b/src/main/java/services/VmNicService.java
@@ -141,7 +141,7 @@ public interface VmNicService extends MeasurableService {
     /**
      * Reference to the service that manages the network filter parameters of the NIC.
      *
-     * A single top-level network filter may assigned to the NIC by the NIC's xref:types/vnic_profile[vNIC Profile].
+     * A single top-level network filter may assigned to the NIC by the NIC's xref:types-vnic_profile[vNIC Profile].
      *
      * @author Dominik Holler <dholler@redhat.com>
      * @date 13 Dec 2016

--- a/src/main/java/services/VmService.java
+++ b/src/main/java/services/VmService.java
@@ -74,7 +74,7 @@ public interface VmService extends MeasurableService {
     /**
      * Permanently restores the virtual machine to the state of the previewed snapshot.
      *
-     * See the xref:services/vm/methods/preview_snapshot[preview_snapshot] operation for details.
+     * See the xref:services-vm-methods-preview_snapshot[preview_snapshot] operation for details.
      *
      * @author Juan Hernandez <juan.hernandez@redhat.com>
      * @author Megan Lewis <melewis@redhat.com>
@@ -651,8 +651,8 @@ public interface VmService extends MeasurableService {
      *
      * The snapshot is indicated with the `snapshot.id` parameter. It is restored temporarily, so that the content can
      * be inspected. Once that inspection is finished, the state of the virtual machine can be made permanent, using the
-     * xref:services/vm/methods/commit_snapshot[commit_snapshot] method, or discarded using the
-     * xref:services/vm/methods/undo_snapshot[undo_snapshot] method.
+     * xref:services-vm-methods-commit_snapshot[commit_snapshot] method, or discarded using the
+     * xref:services-vm-methods-undo_snapshot[undo_snapshot] method.
      *
      * @author Juan Hernandez <juan.hernandez@redhat.com>
      * @author Megan Lewis <melewis@redhat.com>
@@ -738,7 +738,7 @@ public interface VmService extends MeasurableService {
      * Apply an automatic CPU and NUMA configuration on the VM.
      *
      * IMPORTANT: Since version 4.5 of the engine this operation is deprecated, and preserved only for backwards
-     * compatibility. It will be removed in the future. Instead please use PUT followed by xref:services/vm/methods/update[update operation].
+     * compatibility. It will be removed in the future. Instead please use PUT followed by xref:services-vm-methods-update[update operation].
      *
      * An example for a request:
      * [source]
@@ -1515,7 +1515,7 @@ public interface VmService extends MeasurableService {
      *
      * In order to obtain an authentication token for a specific protocol, for
      * example for VNC, use the `ticket` method of the
-     * xref:services/vm_graphics_console[service], which manages the graphics consoles of the virtual machine, by sending
+     * xref:services-vm_graphics_console[service], which manages the graphics consoles of the virtual machine, by sending
      * a request:
      *
      * [source]
@@ -1550,7 +1550,7 @@ public interface VmService extends MeasurableService {
     /**
      * Restores the virtual machine to the state it had before previewing the snapshot.
      *
-     * See the xref:services/vm/methods/preview_snapshot[preview_snapshot] operation for details.
+     * See the xref:services-vm-methods-preview_snapshot[preview_snapshot] operation for details.
      *
      * @author Juan Hernandez <juan.hernandez@redhat.com:
      * @author Megan Lewis <melewis@redhat.com>

--- a/src/main/java/services/VmsService.java
+++ b/src/main/java/services/VmsService.java
@@ -168,7 +168,7 @@ public interface VmsService {
      * ----
      *
      * In order to boot from CDROM, you first need to insert a disk, as described in the
-     * xref:services/vm_cdrom[CDROM service]. Then booting from that CDROM can be specified using the `os.boot.devices`
+     * xref:services-vm_cdrom[CDROM service]. Then booting from that CDROM can be specified using the `os.boot.devices`
      * attribute:
      *
      * [source,xml]
@@ -283,7 +283,7 @@ public interface VmsService {
          * Specifies if and how the auto CPU and NUMA configuration is applied.
          *
          * IMPORTANT: Since version 4.5 of the engine this operation is deprecated, and preserved only for backwards
-         * compatibility. It will be removed in the future. Instead please use POST followed by xref:services/vms/methods/add[add operation].
+         * compatibility. It will be removed in the future. Instead please use POST followed by xref:services-vms-methods-add[add operation].
          *
          * An example for a request:
          *

--- a/src/main/java/services/VnicProfilesService.java
+++ b/src/main/java/services/VnicProfilesService.java
@@ -64,7 +64,7 @@ public interface VnicProfilesService {
      *
      * Please note that there is a default network filter to each VNIC profile.
      * For more details of how the default network filter is calculated please refer to
-     * the documentation in xref:services/network_filters[NetworkFilters].
+     * the documentation in xref:services-network_filters[NetworkFilters].
      *
      * NOTE: The automatically created vNIC profile for the external network will be without network filter.
      *

--- a/src/main/java/services/aaa/GroupService.java
+++ b/src/main/java/services/aaa/GroupService.java
@@ -28,7 +28,7 @@ import types.Group;
 
 /**
  * Manages a group of users. Use this service to either get groups details or remove groups. In order
- * to add new groups please use xref:services/groups[service] that manages the collection of groups.
+ * to add new groups please use xref:services-groups[service] that manages the collection of groups.
  *
  * @author Ondra Machacek <omachace@redhat.com>
  * @date 24 Apr 2017

--- a/src/main/java/services/aaa/SshPublicKeyService.java
+++ b/src/main/java/services/aaa/SshPublicKeyService.java
@@ -35,7 +35,7 @@ public interface SshPublicKeyService {
      * Replaces the key with a new resource.
      *
      * IMPORTANT: Since version 4.4.8 of the engine this operation is deprecated, and preserved only for backwards
-     * compatibility. It will be removed in the future. Instead please use DELETE followed by xref:services/ssh_public_keys/methods/add[add operation].
+     * compatibility. It will be removed in the future. Instead please use DELETE followed by xref:services-ssh_public_keys-methods-add[add operation].
      *
      * @deprecated 4.4.8
      */

--- a/src/main/java/services/aaa/UserService.java
+++ b/src/main/java/services/aaa/UserService.java
@@ -32,7 +32,7 @@ import static org.ovirt.api.metamodel.language.ApiLanguage.optional;
  * A service to manage a user in the system.
  * Use this service to either get users details or remove users.
  * In order to add new users please use
- * xref:services/users[users].
+ * xref:services-users[users].
  *
  * @author Oved Ourfali <oourfali@redhat.com>
  * @date 28 Nov 2016
@@ -116,7 +116,7 @@ public interface UserService {
      * ----
      *
      * IMPORTANT: Since version 4.4.5 of the engine this operation is deprecated, and preserved only for backwards
-     * compatibility. It will be removed in the future. Please use the xref:services/user_option[options]
+     * compatibility. It will be removed in the future. Please use the xref:services-user_option[options]
      * endpoint instead.
      *
      * @author Bohdan Iakymets <biakymet@redhat.com>

--- a/src/main/java/services/gluster/GlusterBrickService.java
+++ b/src/main/java/services/gluster/GlusterBrickService.java
@@ -98,7 +98,7 @@ public interface GlusterBrickService extends MeasurableService {
      *
      * Removes a brick from the underlying gluster volume and deletes entries from database. This can be used only when
      * removing a single brick without data migration. To remove multiple bricks and with data migration, use
-     * xref:services/gluster_bricks/methods/migrate[migrate] instead.
+     * xref:services-gluster_bricks-methods-migrate[migrate] instead.
      *
      * For example, to delete brick `234` from gluster volume `123`, send a request like this:
      *
@@ -122,8 +122,8 @@ public interface GlusterBrickService extends MeasurableService {
      * Replaces this brick with a new one.
      *
      * IMPORTANT: This operation has been deprecated since version 3.5 of the engine and will be removed in the future.
-     * Use xref:services/gluster_bricks/methods/add[add brick(s)] and
-     * xref:services/gluster_bricks/methods/migrate[migrate brick(s)] instead.
+     * Use xref:services-gluster_bricks-methods-add[add brick(s)] and
+     * xref:services-gluster_bricks-methods-migrate[migrate brick(s)] instead.
      *
      * @author Sahina Bose <sabose@redhat.com>
      * @date 12 Dec 2016

--- a/src/main/java/services/gluster/GlusterBricksService.java
+++ b/src/main/java/services/gluster/GlusterBricksService.java
@@ -200,8 +200,8 @@ public interface GlusterBricksService {
      *
      * Removing bricks is a two-step process, where the data on bricks to be removed, is first migrated to remaining
      * bricks. Once migration is completed the removal of bricks is confirmed via the API
-     * xref:services/gluster_bricks/methods/remove[remove]. If at any point, the action needs to be cancelled
-     * xref:services/gluster_bricks/methods/stop_migrate[stopmigrate] has to be called.
+     * xref:services-gluster_bricks-methods-remove[remove]. If at any point, the action needs to be cancelled
+     * xref:services-gluster_bricks-methods-stop_migrate[stopmigrate] has to be called.
      *
      * For instance, to delete a brick from a gluster volume with id `123`, send a request:
      *
@@ -224,7 +224,7 @@ public interface GlusterBricksService {
      * ----
      *
      * The migration process can be tracked from the job id returned from the API using
-     * xref:services/job/methods/get[job] and steps in job using xref:services/step/methods/get[step]
+     * xref:services-job-methods-get[job] and steps in job using xref:services-step-methods-get[step]
      *
      * @author Sahina Bose <sabose@redhat.com>
      * @date 12 Dec 2016
@@ -255,7 +255,7 @@ public interface GlusterBricksService {
      * Removes bricks from gluster volume.
      *
      * The recommended way to remove bricks without data loss is to first migrate the data using
-     * xref:services/gluster_bricks/methods/stop_migrate[stopmigrate] and then removing them. If migrate was not called on
+     * xref:services-gluster_bricks-methods-stop_migrate[stopmigrate] and then removing them. If migrate was not called on
      * bricks prior to remove, the bricks are removed without data migration which may lead to data loss.
      *
      * For example, to delete the bricks from gluster volume `123`, send a request like this:
@@ -341,7 +341,7 @@ public interface GlusterBricksService {
 //        }
         /**
          * List of bricks for which data migration needs to be stopped. This list should match the arguments passed to
-         * xref:services/gluster_bricks/methods/migrate[migrate].
+         * xref:services-gluster_bricks-methods-migrate[migrate].
          *
          * @author Sahina Bose <sabose@redhat.com>
          * @date 12 Dec 2016

--- a/src/main/java/services/openstack/OpenstackNetworkService.java
+++ b/src/main/java/services/openstack/OpenstackNetworkService.java
@@ -48,7 +48,7 @@ public interface OpenstackNetworkService {
          * using the `id` or `name` attributes. The rest of
          * the attributes will be ignored.
          *
-         * NOTE: If xref:types/open_stack_network_provider/attributes/auto_sync[`auto_sync`] is
+         * NOTE: If xref:types-open_stack_network_provider-attributes-auto_sync[`auto_sync`] is
          * enabled for the provider, the network might be imported automatically. To
          * prevent this, automatic import can be disabled by setting the `auto_sync` to false,
          * and enabling it again after importing the network.

--- a/src/main/java/types/CloudInit.java
+++ b/src/main/java/types/CloudInit.java
@@ -23,8 +23,8 @@ import org.ovirt.api.metamodel.annotations.Type;
  * Deprecated type to specify _cloud-init_ configuration.
  *
  * This type has been deprecated and replaced by alternative attributes inside the
- * xref:types/initialization[Initialization] type. See the
- * xref:types/initialization/attributes/cloud_init[cloud_init] attribute documentation for details.
+ * xref:types-initialization[Initialization] type. See the
+ * xref:types-initialization-attributes-cloud_init[cloud_init] attribute documentation for details.
  *
  * @author Juan Hernandez <juan.hernandez@redhat.com>
  * @author Byron Gravenorst <bgraveno@redhat.com>

--- a/src/main/java/types/Cluster.java
+++ b/src/main/java/types/Cluster.java
@@ -460,9 +460,9 @@ public interface Cluster extends Identified {
      * the networks of the referenced network provider are available on every host
      * in the cluster.
      * External network providers of a cluster can only be set during
-     * xref:services/clusters/methods/add[adding the cluster].
+     * xref:services-clusters-methods-add[adding the cluster].
      * This value may be overwritten for individual hosts during
-     * xref:services/hosts/methods/add[adding the host].
+     * xref:services-hosts-methods-add[adding the host].
      *
      * @author Dominik Holler <dholler@redhat.com>
      * @author Tahlia Richardson <trichard@redhat.com>

--- a/src/main/java/types/Disk.java
+++ b/src/main/java/types/Disk.java
@@ -100,7 +100,7 @@ public interface Disk extends Device {
      * The type of interface driver used to connect the disk device to the virtual machine.
      *
      * IMPORTANT: This attribute only makes sense for disks that are actually connected to virtual machines, and in
-     * version 4 of the API it has been moved to the xref:types/disk_attachment[DiskAttachment] type. It is preserved
+     * version 4 of the API it has been moved to the xref:types-disk_attachment[DiskAttachment] type. It is preserved
      * here only for backwards compatibility, and it will be removed in the future.
      *
      * @author Juan Hernandez <juan.hernandez@redhat.com>
@@ -151,7 +151,7 @@ public interface Disk extends Device {
      * Indicates if the disk is marked as bootable.
      *
      * IMPORTANT: This attribute only makes sense for disks that are actually connected to virtual machines, and in
-     * version 4 of the API it has been moved to the xref:types/disk_attachment[DiskAttachment] type. It is preserved
+     * version 4 of the API it has been moved to the xref:types-disk_attachment[DiskAttachment] type. It is preserved
      * here only for backwards compatibility, and it will be removed in the future.
      *
      * @author Juan Hernandez <juan.hernandez@redhat.com>
@@ -243,11 +243,11 @@ public interface Disk extends Device {
     /**
      * Indicates if the disk is in read-only mode.
      *
-     * Since version 4.0 this attribute is not shown in the API and was moved to xref:types/disk_attachment[DiskAttachment].
+     * Since version 4.0 this attribute is not shown in the API and was moved to xref:types-disk_attachment[DiskAttachment].
      *
      * Since version 4.1.2 of {engine-name} this attribute is deprecated, and it will be removed in the future.
      * In order to attach a disk in read only mode use the `read_only` attribute
-     * of the xref:types/disk_attachment[DiskAttachment] type. For example:
+     * of the xref:types-disk_attachment[DiskAttachment] type. For example:
      *
      * ....
      * POST /ovirt-engine/api/vms/123/diskattachments

--- a/src/main/java/types/ExternalStatus.java
+++ b/src/main/java/types/ExternalStatus.java
@@ -20,8 +20,8 @@ import org.ovirt.api.metamodel.annotations.Type;
 
 /**
  * Represents an external status.
- * This status is currently used for xref:types/host[hosts]
- * and xref:types/storage_domain[storage domains], and allows an external
+ * This status is currently used for xref:types-host[hosts]
+ * and xref:types-storage_domain[storage domains], and allows an external
  * system to update status of objects it is aware of.
  *
  * @author Oved Ourfali <oourfali@redhat.com>

--- a/src/main/java/types/Host.java
+++ b/src/main/java/types/Host.java
@@ -377,8 +377,8 @@ public interface Host extends Identified {
      *
      * IMPORTANT: When a host or collection of hosts is retrieved, this attribute is not included unless the
      * `all_content` parameter of the operation is explicitly set to `true`. See the documentation of the
-     * operations that retrieve xref:services/host/methods/get/parameters/all_content[one] or
-     * xref:services/hosts/methods/list/parameters/all_content[multiple] hosts for details.
+     * operations that retrieve xref:services-host-methods-get-parameters-all_content[one] or
+     * xref:services-hosts-methods-list-parameters-all_content[multiple] hosts for details.
      *
      * @author Oved Ourfali <oourfali@redhat.com>
      * @author Tahlia Richardson <trichard@redhat.com>
@@ -637,7 +637,7 @@ public interface Host extends Identified {
      * External network providers provisioned on the host.
      *
      * This attribute is read-only. Setting it will have no effect on the host.
-     * The value of this parameter reflects the xref:services/cluster_external_providers[Default Network Provider]
+     * The value of this parameter reflects the xref:services-cluster_external_providers[Default Network Provider]
      * of the cluster.
      *
      * @author Dominik Holler <dholler@redhat.com>

--- a/src/main/java/types/HostNic.java
+++ b/src/main/java/types/HostNic.java
@@ -50,7 +50,7 @@ import org.ovirt.api.metamodel.annotations.Type;
  * </host_nic>
  * ----
  *
- * A bonded interface is represented as a xref:types/host_nic[HostNic] object
+ * A bonded interface is represented as a xref:types-host_nic[HostNic] object
  * containing the `bonding` and `slaves` attributes.
  *
  * For example, the XML representation of a bonded host NIC looks like this:

--- a/src/main/java/types/ImageTransfer.java
+++ b/src/main/java/types/ImageTransfer.java
@@ -33,7 +33,7 @@ public interface ImageTransfer extends Identified {
 
     /**
      * The URL of the proxy server that the user inputs or outputs to. This attribute is
-     * available only if the image transfer is in the xref:types/image_transfer_phase[transferring]
+     * available only if the image transfer is in the xref:types-image_transfer_phase[transferring]
      * phase. See `phase` for details.
      *
      * @author Amit Aviram <aaviram@redhat.com>
@@ -49,7 +49,7 @@ public interface ImageTransfer extends Identified {
      *
      * This is as an alternative to the `proxy_url`. I.e. if the client has access to the host machine, it could bypass
      * the proxy and transfer directly to the host, potentially improving the throughput performance. This attribute is
-     * available only if the image transfer is in the xref:types/image_transfer_phase[transferring]
+     * available only if the image transfer is in the xref:types-image_transfer_phase[transferring]
      * phase. See `phase` for details.
      *
      * @author Daniel Erez <derez@redhat.com>
@@ -62,7 +62,7 @@ public interface ImageTransfer extends Identified {
     /**
      * The current phase of the image transfer in progress. Each transfer needs a managed
      * session, which must be opened for the user to input or output an image.
-     * Please refer to xref:services/image_transfer[image transfer] for further
+     * Please refer to xref:services-image_transfer[image transfer] for further
      * documentation.
      *
      * @author Amit Aviram <aaviram@redhat.com>

--- a/src/main/java/types/ImageTransferDirection.java
+++ b/src/main/java/types/ImageTransferDirection.java
@@ -19,12 +19,12 @@ package types;
 import org.ovirt.api.metamodel.annotations.Type;
 
 /**
- * The xref:types/image_transfer[image transfer] direction for a transfer.
+ * The xref:types-image_transfer[image transfer] direction for a transfer.
  *
  * When adding a new transfer, the user can choose whether the transfer will be to an image, choosing `upload`,
  * or to transfer from an image- choosing `download` as an ImageTransferDirection.
  *
- * Please refer to xref:services/image_transfer[image transfer] for further
+ * Please refer to xref:services-image_transfer[image transfer] for further
  * documentation.
  *
  * @author Amit Aviram <aaviram@redhat.com>

--- a/src/main/java/types/ImageTransferPhase.java
+++ b/src/main/java/types/ImageTransferPhase.java
@@ -19,10 +19,10 @@ package types;
 import org.ovirt.api.metamodel.annotations.Type;
 
 /**
- * A list of possible phases for an xref:types/image_transfer[image transfer] entity. Each of these values
+ * A list of possible phases for an xref:types-image_transfer[image transfer] entity. Each of these values
  * defines a specific point in a transfer flow.
  *
- * Please refer to xref:services/image_transfer[image transfer] for more
+ * Please refer to xref:services-image_transfer[image transfer] for more
  * information.
  *
  * @author Amit Aviram <aaviram@redhat.com>
@@ -70,7 +70,7 @@ public enum ImageTransferPhase {
 
     /**
      * The phase where the transfer has been resumed by the client calling
-     * xref:services/image_transfer/methods/resume[resume]. Resuming starts a new session, and after calling it,
+     * xref:services-image_transfer-methods-resume[resume]. Resuming starts a new session, and after calling it,
      * the phase will be changed to `transferring`, or `paused_system` in case of a failure.
      *
      * @author Amit Aviram <aaviram@redhat.com>
@@ -84,7 +84,7 @@ public enum ImageTransferPhase {
     /**
      * This phase means the session timed out, or some other error occurred
      * with this transfer; for example ovirt-imageio-daemon is not running in the selected host.
-     * To resume the session, the client should call xref:services/image_transfer/methods/resume[resume]. After
+     * To resume the session, the client should call xref:services-image_transfer-methods-resume[resume]. After
      * resuming, the phase will change to `resuming`.
      *
      * @author Amit Aviram <aaviram@redhat.com>
@@ -97,7 +97,7 @@ public enum ImageTransferPhase {
 
     /**
      * This phase is a result of a pause call by the user, using
-     * xref:services/image_transfer/methods/pause[pause].
+     * xref:services-image_transfer-methods-pause[pause].
      *
      * @author Amit Aviram <aaviram@redhat.com>
      * @author Byron Gravenorst <bgraveno@redhat.com>
@@ -123,11 +123,11 @@ public enum ImageTransferPhase {
     CANCELLED,
 
     /**
-     * This phase will be set when the user calls xref:services/image_transfer/methods/finalize[finalize]. Calling
+     * This phase will be set when the user calls xref:services-image_transfer-methods-finalize[finalize]. Calling
      * finalize is essential to finish the transfer session, and finish using the targeted image. After finalizing,
      * the phase will be changed to `finished_success` or `finished_failure`.
      *
-     * Refer to xref:services/image_transfer[image transfer] for more information.
+     * Refer to xref:services-image_transfer[image transfer] for more information.
      *
      * @author Amit Aviram <aaviram@redhat.com>
      * @author Byron Gravenorst <bgraveno@redhat.com>

--- a/src/main/java/types/ImageTransferTimeoutPolicy.java
+++ b/src/main/java/types/ImageTransferTimeoutPolicy.java
@@ -19,12 +19,12 @@ package types;
 import org.ovirt.api.metamodel.annotations.Type;
 
 /**
- * The xref:types/image_transfer[image transfer] timeout policy.
+ * The xref:types-image_transfer[image transfer] timeout policy.
  *
  * Define how the system handles a transfer when the client is inactive
  * for inactivityTimeout seconds.
  *
- * Please refer to xref:services/image_transfer[image transfer] for further
+ * Please refer to xref:services-image_transfer[image transfer] for further
  * documentation.
  *
  * @author Ahmad Khiet <akhiet@redhat.com>

--- a/src/main/java/types/Initialization.java
+++ b/src/main/java/types/Initialization.java
@@ -25,9 +25,9 @@ public interface Initialization {
     /**
      * Deprecated attribute to specify _cloud-init_ configuration.
      *
-     * This attribute and the xref:types/cloud_init[CloudInit] type have been deprecated and will be
+     * This attribute and the xref:types-cloud_init[CloudInit] type have been deprecated and will be
      * removed in the future.  To specify the _cloud-init_ configuration, use the attributes inside
-     * the xref:types/initialization[Initialization] type. The mapping between the attributes
+     * the xref:types-initialization[Initialization] type. The mapping between the attributes
      * of these two types are as follows:
      *
      * |===
@@ -82,7 +82,7 @@ public interface Initialization {
      * Attribute specifying the cloud-init protocol to
      * use for formatting the cloud-init network parameters.
      * If omitted, a default value is used, as described in
-     * the xref:types/cloud_init_network_protocol[CloudInitNetworkProtocol]
+     * the xref:types-cloud_init_network_protocol[CloudInitNetworkProtocol]
      *
      *
      * @author Eitan Raviv <eraviv@redhat.com>

--- a/src/main/java/types/MemoryPolicy.java
+++ b/src/main/java/types/MemoryPolicy.java
@@ -35,8 +35,8 @@ public interface MemoryPolicy {
      * The {engine-name} internally rounds this value down to whole MiB (1MiB = 2^20^ bytes).
      *
      * NOTE: It can be updated while the virtual machine is running since {product-name} 4.2 onwards, provided
-     * xref:types/vm/attributes/memory[memory] is updated in the same request as well, and the virtual machine is in
-     * state xref:types/vm_status/values/up[up].
+     * xref:types-vm-attributes-memory[memory] is updated in the same request as well, and the virtual machine is in
+     * state xref:types-vm_status-values-up[up].
      *
      * @author Jakub Niedermertl <jniederm@redhat.com>
      * @author Tahlia Richardson <trichard@redhat.com>

--- a/src/main/java/types/NetworkFilterParameter.java
+++ b/src/main/java/types/NetworkFilterParameter.java
@@ -19,7 +19,7 @@ import org.ovirt.api.metamodel.annotations.Link;
 import org.ovirt.api.metamodel.annotations.Type;
 
 /**
- * Parameter for the xref:types/network_filter[network filter].
+ * Parameter for the xref:types-network_filter[network filter].
  *
  * See link:https://libvirt.org/formatnwfilter.html#nwfconceptsvars[Libvirt-Filters] for further details.
  * This is a example of the XML representation:

--- a/src/main/java/types/OpenStackNetworkProvider.java
+++ b/src/main/java/types/OpenStackNetworkProvider.java
@@ -132,22 +132,22 @@ public interface OpenStackNetworkProvider extends OpenStackProvider {
     @Link OpenStackSubnet[] subnets();
 
     /**
-     * Indicates if the xref:types/network[networks] of this provider are automatically synchronized.
+     * Indicates if the xref:types-network[networks] of this provider are automatically synchronized.
      *
      * If `true`, the networks of this provider are automatically and cyclically synchronized to {product-name} in
      * the background.
      * This means that all new networks of this provider are imported, and all discarded networks are removed
-     * from all xref:types/cluster[clusters] that have this external provider as the default provider.
+     * from all xref:types-cluster[clusters] that have this external provider as the default provider.
      * If the name of a network is changed on the provider, the change is synchronized to the network entity in
      * {product-name}. Furthermore, if a new cluster that has the provider as the default provider is added,
      * already imported networks are attached to this new cluster during synchronization.
      *
      * The automatically initiated import triggers the following steps:
      *
-     * - The networks of the external provider will be imported to every xref:types/data_center[data center]
+     * - The networks of the external provider will be imported to every xref:types-data_center[data center]
      *   in the data centers of the clusters that have that external provider as the default provider.
      *
-     * - A xref:types/vnic_profile[vNIC profile] will be created for each involved data center and network.
+     * - A xref:types-vnic_profile[vNIC profile] will be created for each involved data center and network.
      *
      * - The networks will be assigned to each cluster that has that external provider as the default provider.
      *
@@ -180,7 +180,7 @@ public interface OpenStackNetworkProvider extends OpenStackProvider {
     Boolean unmanaged();
 
     /**
-     * Defines the domain name of the `username` in xref:types/external_provider[ExternalProvider] for
+     * Defines the domain name of the `username` in xref:types-external_provider[ExternalProvider] for
      * OpenStack Identity API v3.
      *
      * @author Dominik Holler <dholler@redhat.com>

--- a/src/main/java/types/OperatingSystem.java
+++ b/src/main/java/types/OperatingSystem.java
@@ -32,7 +32,7 @@ public interface OperatingSystem {
      * Operating system name in human readable form.
      *
      * For example `Fedora` or `RHEL`. In general one of the names returned by
-     * the xref:services/operating_systems[operating system] service.
+     * the xref:services-operating_systems[operating system] service.
      *
      * NOTE: Read only for hosts.
      *

--- a/src/main/java/types/OsType.java
+++ b/src/main/java/types/OsType.java
@@ -20,8 +20,8 @@ import org.ovirt.api.metamodel.annotations.Type;
 /**
  * Type representing kind of operating system.
  *
- * WARNING: This type has been deprecated with the introduction of the xref:types/operating_system_info[OperatingSystemInfo] type.
- * Operating systems are available as a top-level collection in the API: xref:services/operating_systems[operating_systems].
+ * WARNING: This type has been deprecated with the introduction of the xref:types-operating_system_info[OperatingSystemInfo] type.
+ * Operating systems are available as a top-level collection in the API: xref:services-operating_systems[operating_systems].
  *
  * The end-user declares the type of the operating system installed in the virtual machine (guest operating system) by
  * selecting one of these values. This declaration enables the system to tune the virtual machine configuration for

--- a/src/main/java/types/Qos.java
+++ b/src/main/java/types/Qos.java
@@ -22,16 +22,16 @@ import org.ovirt.api.metamodel.annotations.Type;
 /**
  * This type represents the attributes to define Quality of service (QoS).
  *
- * For storage the `type` is xref:types/qos_type[storage], the attributes `max_throughput`, `max_read_throughput`,
+ * For storage the `type` is xref:types-qos_type[storage], the attributes `max_throughput`, `max_read_throughput`,
  * `max_write_throughput`, `max_iops`, `max_read_iops` and `max_write_iops` are relevant.
  *
- * For resources with computing capabilities the `type` is xref:types/qos_type[cpu], the attribute `cpu_limit` is
+ * For resources with computing capabilities the `type` is xref:types-qos_type[cpu], the attribute `cpu_limit` is
  * relevant.
  *
- * For virtual machines networks the `type` is xref:types/qos_type[network], the attributes `inbound_average`,
+ * For virtual machines networks the `type` is xref:types-qos_type[network], the attributes `inbound_average`,
  * `inbound_peak`, `inbound_burst`, `outbound_average`, `outbound_peak` and `outbound_burst` are relevant.
  *
- * For host networks the `type` is xref:types/qos_type[hostnetwork], the attributes `outbound_average_linkshare`,
+ * For host networks the `type` is xref:types-qos_type[hostnetwork], the attributes `outbound_average_linkshare`,
  * `outbound_average_upperlimit` and `outbound_average_realtime` are relevant.
  *
  * @author Dominik Holler <dholler@redhat.com>

--- a/src/main/java/types/QosType.java
+++ b/src/main/java/types/QosType.java
@@ -18,7 +18,7 @@ package types;
 import org.ovirt.api.metamodel.annotations.Type;
 
 /**
- * This type represents the kind of resource the xref:types/qos[Quality of service (QoS)] can be assigned to.
+ * This type represents the kind of resource the xref:types-qos[Quality of service (QoS)] can be assigned to.
  *
  * @author Dominik Holler <dholler@redhat.com>
  * @date 12 Dec 2016
@@ -27,7 +27,7 @@ import org.ovirt.api.metamodel.annotations.Type;
 @Type
 public enum QosType {
     /**
-     * The xref:types/qos[Quality of service (QoS)] can be assigned to storage.
+     * The xref:types-qos[Quality of service (QoS)] can be assigned to storage.
      *
      * @author Dominik Holler <dholler@redhat.com>
      * @date 12 Dec 2016
@@ -36,7 +36,7 @@ public enum QosType {
     STORAGE,
 
     /**
-     * The xref:types/qos[Quality of service (QoS)] can be assigned to resources with computing capabilities.
+     * The xref:types-qos[Quality of service (QoS)] can be assigned to resources with computing capabilities.
      *
      * @author Dominik Holler <dholler@redhat.com>
      * @date 12 Dec 2016
@@ -45,7 +45,7 @@ public enum QosType {
     CPU,
 
     /**
-     * The xref:types/qos[Quality of service (QoS)] can be assigned to virtual machines networks.
+     * The xref:types-qos[Quality of service (QoS)] can be assigned to virtual machines networks.
      *
      * @author Dominik Holler <dholler@redhat.com>
      * @date 12 Dec 2016
@@ -54,7 +54,7 @@ public enum QosType {
     NETWORK,
 
     /**
-     * The xref:types/qos[Quality of service (QoS)] can be assigned to host networks.
+     * The xref:types-qos[Quality of service (QoS)] can be assigned to host networks.
      *
      * @author Dominik Holler <dholler@redhat.com>
      * @date 12 Dec 2016

--- a/src/main/java/types/RegistrationVnicProfileMapping.java
+++ b/src/main/java/types/RegistrationVnicProfileMapping.java
@@ -51,7 +51,7 @@ import org.ovirt.api.metamodel.annotations.Type;
  *
  * |===
  *
- * Then the following snippet should be added to xref:types/registration_configuration[RegistrationConfiguration]
+ * Then the following snippet should be added to xref:types-registration_configuration[RegistrationConfiguration]
  *
  * [source,xml]
  * ----

--- a/src/main/java/types/StorageDomain.java
+++ b/src/main/java/types/StorageDomain.java
@@ -68,8 +68,8 @@ public interface StorageDomain extends Identified {
     StorageFormat storageFormat();
 
     /**
-     * Serves as the default value of `wipe_after_delete` for xref:types/disk[disk]s on this
-     * xref:types/storage_domain[storage domain].
+     * Serves as the default value of `wipe_after_delete` for xref:types-disk[disk]s on this
+     * xref:types-storage_domain[storage domain].
      *
      * That is, newly created disks will get their `wipe_after_delete` value from their storage domains by default.
      * Note that the configuration value `SANWipeAfterDelete` serves as the default value of block storage domains'
@@ -82,8 +82,8 @@ public interface StorageDomain extends Identified {
     Boolean wipeAfterDelete();
 
     /**
-     * Indicates whether xref:types/disk[disk]s' blocks on block
-     * xref:types/storage_domain[storage domain]s will be
+     * Indicates whether xref:types-disk[disk]s' blocks on block
+     * xref:types-storage_domain[storage domain]s will be
      * discarded right before they are deleted.
      *
      * If true, and a disk on this storage domain has its `wipe_after_delete` value enabled, then when the disk is
@@ -98,7 +98,7 @@ public interface StorageDomain extends Identified {
      * * Discard after delete will always be `false` for non block storage types.
      *
      * * Discard after delete can be set to `true` only if the storage domain
-     * xref:types/storage_domain/attributes/supports_discard[supports discard].
+     * xref:types-storage_domain-attributes-supports_discard[supports discard].
      *
      * @author Idan Shaby <ishaby@redhat.com>
      * @date 29 November 2016
@@ -109,8 +109,8 @@ public interface StorageDomain extends Identified {
 
     /**
      * Indicates whether a block storage domain supports discard operations.
-     * A xref:types/storage_domain[storage domain] only supports discard
-     * if all of the xref:types/logical_unit[logical unit]s that it is built
+     * A xref:types-storage_domain[storage domain] only supports discard
+     * if all of the xref:types-logical_unit[logical unit]s that it is built
      * from support discard; that is, if each logical unit's `discard_max_size` value
      * is greater than 0.
      * This is one of the conditions necessary for a virtual disk in this
@@ -127,9 +127,9 @@ public interface StorageDomain extends Identified {
     /**
      * Indicates whether a block storage domain supports the property that
      * discard zeroes the data.
-     * A xref:types/storage_domain[storage domain] only supports the property that
+     * A xref:types-storage_domain[storage domain] only supports the property that
      * discard zeroes the data if all of the
-     * xref:types/logical_unit[logical unit]s that it is built from support it;
+     * xref:types-logical_unit[logical unit]s that it is built from support it;
      * that is, if each logical unit's `discard_zeroes_data` value is true.
      *
      * IMPORTANT: Since version 4.2.1 of the system, the support for this attribute has

--- a/src/main/java/types/StorageDomainType.java
+++ b/src/main/java/types/StorageDomainType.java
@@ -18,7 +18,7 @@ package types;
 import org.ovirt.api.metamodel.annotations.Type;
 
 /**
- * Indicates the kind of data managed by a xref:types/storage_domain[storage domain].
+ * Indicates the kind of data managed by a xref:types-storage_domain[storage domain].
  *
  * @author Aleksei Slaikovski <aslaikov@redhat.com>
  * @date 24 Apr 2017

--- a/src/main/java/types/StorageFormat.java
+++ b/src/main/java/types/StorageFormat.java
@@ -19,7 +19,7 @@ package types;
 import org.ovirt.api.metamodel.annotations.Type;
 
 /**
- * Type which represents a format of xref:types/storage_domain[storage domain].
+ * Type which represents a format of xref:types-storage_domain[storage domain].
  *
  * @author Aleksei Slaikovskii <aslaikov@redhat.com>
  * @date 24 Apr 2017

--- a/src/main/java/types/User.java
+++ b/src/main/java/types/User.java
@@ -103,7 +103,7 @@ public interface User extends Identified {
      * which are used to customize the settings per individual
      * user.
      * Note that since version 4.4.5 this property is deprecated and preserved only for backwards
-     * compatibility. It will be removed in the future. Please use the xref:services/user_option[options]
+     * compatibility. It will be removed in the future. Please use the xref:services-user_option[options]
      * endpoint instead.
      *
      * @author Bohdan Iakymets <biakymet@redhat.com>

--- a/src/main/java/types/VmBase.java
+++ b/src/main/java/types/VmBase.java
@@ -60,13 +60,13 @@ public interface VmBase extends Identified {
      * ----
      *
      * Memory hot plug is supported from {product-name} 3.6 onwards. You can use the example above to increase
-     * memory while the virtual machine is in state xref:types/vm_status/values/up[up]. The size increment must be
+     * memory while the virtual machine is in state xref:types-vm_status-values-up[up]. The size increment must be
      * dividable by the value of the `HotPlugMemoryBlockSizeMb` configuration value (256 MiB by default). If the memory
      * size increment is not dividable by this value, the memory size change is only stored to next run configuration.
      * Each successful memory hot plug operation creates one or two new memory devices.
      *
      * Memory hot unplug is supported since {product-name} 4.2 onwards. Memory hot unplug can only be performed
-     * when the virtual machine is in state xref:types/vm_status/values/up[up]. Only previously hot plugged memory
+     * when the virtual machine is in state xref:types-vm_status-values-up[up]. Only previously hot plugged memory
      * devices can be removed by the hot unplug operation. The requested memory decrement is rounded down to match sizes
      * of a combination of previously hot plugged memory devices. The requested memory value is stored to next run
      * configuration without rounding.

--- a/src/main/java/types/VnicProfile.java
+++ b/src/main/java/types/VnicProfile.java
@@ -20,7 +20,7 @@ import org.ovirt.api.metamodel.annotations.Link;
 import org.ovirt.api.metamodel.annotations.Type;
 
 /**
- * A vNIC profile is a collection of settings that can be applied to individual xref:types/nic[NIC].
+ * A vNIC profile is a collection of settings that can be applied to individual xref:types-nic[NIC].
  *
  * @author Dominik Holler <dholler@redhat.com>
  * @author Megan Lewis <melewis@redhat.com>
@@ -33,8 +33,8 @@ public interface VnicProfile extends Identified {
     /**
      * Enables port mirroring.
      *
-     * Port mirroring copies layer 3 network traffic on a given xref:types/network[logical network] and
-     * xref:types/host[host] to a NIC on a xref:types/vm[virtual machine]. This virtual machine
+     * Port mirroring copies layer 3 network traffic on a given xref:types-network[logical network] and
+     * xref:types-host[host] to a NIC on a xref:types-vm[virtual machine]. This virtual machine
      * can be used for network debugging and tuning, intrusion detection, and monitoring the behavior of other
      * virtual machines on the same host and logical network. The only
      * traffic copied is internal to one logical network on one host. There is no
@@ -69,10 +69,10 @@ public interface VnicProfile extends Identified {
     CustomProperty[] customProperties();
 
     /**
-     * Enables passthrough to an SR-IOV-enabled xref:types/host_nic[host NIC].
+     * Enables passthrough to an SR-IOV-enabled xref:types-host_nic[host NIC].
      *
      * A vNIC profile enables a NIC to be directly connected to a
-     * xref:types/host_nic_virtual_functions_configuration[virtual function (VF)] of an SR-IOV-enabled
+     * xref:types-host_nic_virtual_functions_configuration[virtual function (VF)] of an SR-IOV-enabled
      * host NIC, if passthrough is enabled. The NIC will then bypass the software network virtualization and
      * connect directly to the VF for direct device assignment.
      *


### PR DESCRIPTION
Changed slashes in internal Asciidoc references ("xref") to hyphens so that the generated Asciidoc model passes validation for publishing on the Customer Portal.