### PR TITLE
Deprecate VmPool.display attribute

### DIFF
--- a/src/main/java/types/VmPool.java
+++ b/src/main/java/types/VmPool.java
@@ -61,10 +61,13 @@ public interface VmPool extends Identified {
     /**
      * The display settings configured for virtual machines in the pool.
      *
+     * WARNING: Please note that this attribute is not working and is now deprecated. Please use `Vm.display` instead.
+     *
      * @author Arik Hadas <ahadas@redhat.com>
-     * @date 24 Apr 2017
-     * @status added
+     * @date 24 Jul 2022
+     * @status updated
      */
+    @Deprecated
     Display display();
 
     /**


### PR DESCRIPTION
VmPool.display attribute is not used by the backend code. It was added
by mistake and should be deprecated to avoid confusion.

Change-Id: Idc06374e8654c0cab10a120004e7db69207a335b
Signed-off-by: Shmuel Melamud <smelamud@redhat.com>