### PR TITLE
BZ2042401 - Image I/O Proxy is replaced by ovirt-imageio

### DIFF
--- a/src/main/java/services/ImageTransferService.java
+++ b/src/main/java/services/ImageTransferService.java
@@ -103,11 +103,10 @@ import annotations.Area;
  *    transfer = transfer_service.get()
  * ----
  *
- * At that stage, if the transfer's phase is xref:types-image_transfer_phase[paused_system], then the session was
- * not successfully established. One possible reason for that is that the ovirt-imageio is not running
- * in the host that was selected for transfer.
+ * At that stage, if the phase of the transfer is <<types/image_transfer_phase, paused_system>>, the session was
+ * not successfully established. This can happen if ovirt-imageio is not running in the selected host.
  * @author Donna DaCosta <ddacosta@redhat.com>
- * @date 26 July 2022
+ * @date 29 July 2022
  * @status updated_by_docs
  * @since 4.5.1
  * The transfer can be resumed by calling xref:services-image_transfer-methods-resume[resume]

--- a/src/main/java/services/ImageTransferService.java
+++ b/src/main/java/services/ImageTransferService.java
@@ -104,8 +104,12 @@ import annotations.Area;
  * ----
  *
  * At that stage, if the transfer's phase is xref:types-image_transfer_phase[paused_system], then the session was
- * not successfully established. One possible reason for that is that the ovirt-imageio-daemon is not running
+ * not successfully established. One possible reason for that is that the ovirt-imageio is not running
  * in the host that was selected for transfer.
+ * @author Donna DaCosta <ddacosta@redhat.com>
+ * @date 26 July 2022
+ * @status updated_by_docs
+ * @since 4.5.1
  * The transfer can be resumed by calling xref:services-image_transfer-methods-resume[resume]
  * of the service that manages it.
  *
@@ -215,11 +219,14 @@ import annotations.Area;
  * Note: If the phase is 'initializing', poll the `image_transfer` till its phase changes to 'transferring'.
  *
  * - Use the 'transfer_url' or 'proxy_url' to invoke a curl command:
- * - use 'transfer_url' for transferring directly from/to ovirt-imageio-daemon,
- *   or, use 'proxy_url' for transferring from/to ovirt-imageio-proxy.
+ * - use 'transfer_url' for transferring directly from/to ovirt-imageio,
+ *   or, use 'proxy_url' for transferring from/to ovirt-imageio.
  *   Note: using the proxy would mitigate scenarios where there's no direct connectivity
  *   to the daemon machine, e.g. vdsm machines are on a different network than the engine.
- *
+ * @author Donna DaCosta <ddacosta@redhat.com>
+ * @date 26 July 2022
+ * @status updated_by_docs
+ * @since 4.5.1
  * -- Download:
  *
  * [source,shell]

--- a/src/main/java/services/ImageTransferService.java
+++ b/src/main/java/services/ImageTransferService.java
@@ -103,7 +103,7 @@ import annotations.Area;
  *    transfer = transfer_service.get()
  * ----
  *
- * At that stage, if the phase of the transfer is <<types/image_transfer_phase, paused_system>>, the session was
+ * At that stage, if the phase of the transfer is xref:types-image_transfer_phase[paused_system], the session was
  * not successfully established. This can happen if ovirt-imageio is not running in the selected host.
  * @author Donna DaCosta <ddacosta@redhat.com>
  * @date 29 July 2022

--- a/src/main/java/types/ImageTransferPhase.java
+++ b/src/main/java/types/ImageTransferPhase.java
@@ -83,15 +83,16 @@ public enum ImageTransferPhase {
 
     /**
      * This phase means the session timed out, or some other error occurred
-     * with this transfer; for example ovirt-imageio-daemon is not running in the selected host.
+     * with this transfer; for example ovirt-imageio is not running in the selected host.
      * To resume the session, the client should call xref:services-image_transfer-methods-resume[resume]. After
      * resuming, the phase will change to `resuming`.
      *
      * @author Amit Aviram <aaviram@redhat.com>
      * @author Byron Gravenorst <bgraveno@redhat.com>
-     * @date 15 Nov 2016
+     * @author Donna DaCosta <ddacosta@redhat.com>
+     * @date 26 July 2022
      * @status updated_by_docs
-     * @since 4.0.4
+     * @since 4.5.1
      */
     PAUSED_SYSTEM,
 


### PR DESCRIPTION
Changed the ovirt-imageio-proxy and ovirt-imageio-daemon to ovirt-imageio per https://bugzilla.redhat.com/show_bug.cgi?id=2042401. 

