### PR TITLE
Add build dependency to maven

### DIFF
--- a/ovirt-engine-api-model.spec.in
+++ b/ovirt-engine-api-model.spec.in
@@ -26,6 +26,9 @@ BuildRequires:	mvn(org.apache.maven.plugins:maven-surefire-plugin)
 BuildRequires:	mvn(org.codehaus.mojo:exec-maven-plugin)
 BuildRequires:	mvn(org.ovirt.maven.plugins:ovirt-jboss-modules-maven-plugin)
 
+# Required to pass COPR build, which uses old xmvn package
+BuildRequires:	maven
+
 Requires:	ovirt-engine-api-metamodel-server
 Requires:	java-11-openjdk-headless >= 1:11.0.0
 Requires:	javapackages-filesystem


### PR DESCRIPTION
Adds build dependency to maven to pass build on COPR for EL8,
which uses old xmvn version

Signed-off-by: Martin Perina <mperina@redhat.com>
