### PR TITLE
Add missing DisplayType values

### DIFF
--- a/src/main/java/types/DisplayType.java
+++ b/src/main/java/types/DisplayType.java
@@ -39,6 +39,7 @@ public enum DisplayType {
      * @date 23 Apr 2017
      * @status added
      */
+    @Deprecated
     VNC,
 
     /**
@@ -49,5 +50,49 @@ public enum DisplayType {
      * @date 23 Apr 2017
      * @status added
      */
-    SPICE;
+    @Deprecated
+    SPICE,
+
+    /**
+     * Display of type CIRRUS
+     * @author Jean-Louis Dupond <jean-louis@dupond.be>
+     * @date 26 May 2023
+     * @status added
+     */
+    @Deprecated
+    CIRRUS,
+
+    /**
+     * Display of type QXL
+     * @author Jean-Louis Dupond <jean-louis@dupond.be>
+     * @date 26 May 2023
+     * @status added
+     */
+    @Deprecated
+    QXL,
+
+    /**
+     * Display of type VGA
+     * @author Jean-Louis Dupond <jean-louis@dupond.be>
+     * @date 26 May 2023
+     * @status added
+     */
+    VGA,
+
+    /**
+     * Display of type BOCHS
+     * @author Jean-Louis Dupond <jean-louis@dupond.be>
+     * @date 26 May 2023
+     * @status added
+     */
+    BOCHS,
+
+  /**
+     * Display of type NONE
+     * This is for headless VM's
+     * @author Jean-Louis Dupond <jean-louis@dupond.be>
+     * @date 26 May 2023
+     * @status added
+     */
+    NONE;
 }


### PR DESCRIPTION
In org.ovirt.engine.core.common.businessentities.DisplayType we have the supported DisplayType's. The API Model DisplayType values do not match these values.

The ovirt-engine code contains code to map VNC and SPICE DisplayType from the API to the businessentities.DisplayType values, but never were the real values added to the API Model.

In this commit we deprecate the 'legacy' DisplayType's in favor of the real DisplayType's.


Change-Id: Ibc9d7cbec88effd62172983da6ab705160ad8879