### PR TITLE
ci: switch generated-documentation-cs8 to cs9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Download generated documentation artifacts
         uses: actions/download-artifact@v4
         with:
-          name: generated-documentation-cs8
+          name: generated-documentation-cs9
           path: target
 
       - name: Install package dependencies


### PR DESCRIPTION
Switch to the cs9 documentation artifact as the cs8 one is not build anymore.