### PR TITLE
build: depend on maven-openjdk11 + set JAVA_HOME

### DIFF
--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -19,6 +19,9 @@ RELEASE=${VERSION[1]-1}
 [[ -d rpmbuild/SOURCES ]] || mkdir -p rpmbuild/SOURCES
 git archive --format=tar HEAD | gzip -9 > rpmbuild/SOURCES/ovirt-engine-api-model-$VERSION.tar.gz
 
+# Set the location of the JDK that will be used for compilation:
+export JAVA_HOME="${JAVA_HOME:=/usr/lib/jvm/java-11}"
+
 # Generate AsciiDoc and HTML documentation
 mvn package -Pgenerate-adoc-html -Dadoc.linkcss=true
 cp target/doc.jar rpmbuild/SOURCES/ovirt-engine-api-model-doc-$VERSION.jar

--- a/ovirt-engine-api-model.spec.in
+++ b/ovirt-engine-api-model.spec.in
@@ -27,7 +27,7 @@ BuildRequires:	mvn(org.codehaus.mojo:exec-maven-plugin)
 BuildRequires:	mvn(org.ovirt.maven.plugins:ovirt-jboss-modules-maven-plugin)
 
 # Required to pass COPR build, which uses old xmvn package
-BuildRequires:	maven
+BuildRequires:	maven-openjdk11
 
 Requires:	ovirt-engine-api-metamodel-server
 Requires:	java-11-openjdk-headless >= 1:11.0.0


### PR DESCRIPTION
Depend on maven-openjdk11 version of Maven to be able to build on Copr which uses another default Java version and set JAVA_HOME to java11.