### PR TITLE
Add EngineBackupInfo containing last backups

### DIFF
--- a/src/main/java/types/Api.java
+++ b/src/main/java/types/Api.java
@@ -72,12 +72,21 @@ import org.ovirt.api.metamodel.annotations.Type;
  *     </storage_domains>
  *   </summary>
  *   <time>2016-12-12T12:22:25.866+01:00</time>
+ *   <engine_backup>
+ *      <last_cinder_backup>2025-01-30T13:18:47.671Z</last_cinder_backup>
+ *      <last_db_backup>2025-01-30T13:18:47.646Z</last_db_backup>
+ *      <last_dwh_backup>2025-01-30T13:18:47.659Z</last_dwh_backup>
+ *      <last_engine_backup>2025-01-30T13:18:47.634Z</last_engine_backup>
+ *      <last_grafana_backup>2025-01-30T13:18:47.694Z</last_grafana_backup>
+ *      <last_keycloak_backup>2025-01-30T13:18:47.682Z</last_keycloak_backup>
+ *   </engine_backup>
  * </api>
  * ----
  *
  * @author Piotr Kliczewski <pkliczew@redhat.com>
  * @author Megan Lewis <melewis@redhat.com>
- * @date 12 Dec 2016
+ * @author Jasper Berton <jasper.berton@team.blue>
+ * @date 03 February 2025
  * @status updated_by_docs
  */
 @Type
@@ -114,9 +123,19 @@ public interface Api {
      *
      * @author Megan Lewis <melewis@redhat.com>
      * @date 15 Nov 2016
-     * status updated_by_docs
+     * @status updated_by_docs
      */
     Date time();
+
+    /**
+     * Object containing info about when the last backup of the engine was made
+     *
+     * @author Jasper Berton <jasper.berton@team.blue>
+     * @date 03 Feb 2025
+     * @status added
+     * @since 4.6.1
+     */
+    EngineBackupInfo engineBackup();
 
     /**
      * Reference to the authenticated user.

--- a/src/main/java/types/EngineBackupInfo.java
+++ b/src/main/java/types/EngineBackupInfo.java
@@ -1,0 +1,96 @@
+/*
+Copyright (c) 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types;
+
+import java.util.Date;
+
+import org.ovirt.api.metamodel.annotations.Type;
+
+/**
+ * Engine Backup
+ *
+ * Contains information about when certain parts of the ovirt-engine instance were last succesfully backed up
+ *
+ * @author Jasper Berton <jasper.berton@team.blue>
+ * @date 03 Feb 2025
+ * @status added
+ * @since 4.6.1
+ */
+@Type
+public interface EngineBackupInfo {
+
+    /**
+     * Date of when last succesfull backup was made of the engine.
+     *
+     * @author Jasper Berton <jasper.berton@team.blue>
+     * @date 03 Feb 2025
+     * @status added
+     * @since 4.6.1
+     */
+    Date lastEngineBackup();
+
+    /**
+     * Date of when last succesfull backup was made of the database.
+     *
+     * @author Jasper Berton <jasper.berton@team.blue>
+     * @date 03 Feb 2025
+     * @status added
+     * @since 4.6.1
+     */
+    Date lastDbBackup();
+
+    /**
+     * Date of when last succesfull backup was made of the DWH.
+     *
+     * @author Jasper Berton <jasper.berton@team.blue>
+     * @date 03 Feb 2025
+     * @status added
+     * @since 4.6.1
+     */
+    Date lastDwhBackup();
+
+    /**
+     * Date of when last succesfull backup was made of the Cinderlib.
+     *
+     * @author Jasper Berton <jasper.berton@team.blue>
+     * @date 03 Feb 2025
+     * @status added
+     * @since 4.6.1
+     */
+    Date lastCinderBackup();
+
+    /**
+     * Date of when last succesfull backup was made of the keycloack DB.
+     *
+     * @author Jasper Berton <jasper.berton@team.blue>
+     * @date 03 Feb 2025
+     * @status added
+     * @since 4.6.1
+     */
+    Date lastKeycloakBackup();
+
+    /**
+     * Date of when last succesfull backup was made of the Grafana.
+     *
+     * @author Jasper Berton <jasper.berton@team.blue>
+     * @date 03 Feb 2025
+     * @status added
+     * @since 4.6.1
+     */
+    Date lastGrafanaBackup();
+
+}


### PR DESCRIPTION
Export a new EngineBackupInfo type containing datetime objects when all the different components were backed up for the last time.