### PR TITLE
ci: don't configure settings.xml on PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,7 @@ jobs:
 
       - name: Set up Maven settings.xml
         uses: s4u/maven-settings-action@v3.1.0
+        if: ${{ github.event_name != 'pull_request' }}
         with:
           path: /root/.m2/settings.xml
           servers: |


### PR DESCRIPTION
PR's from external repositories don't have access to secrets. Skip configuration of settings.xml on PR's as this is useless anyway.