### PR TITLE
api: add description string field to OperatingSystem

### DIFF
--- a/src/main/java/types/OperatingSystem.java
+++ b/src/main/java/types/OperatingSystem.java
@@ -129,5 +129,18 @@ public interface OperatingSystem {
      */
     String customKernelCmdline();
 
+    /**
+     * Specific description of the operating system. Gives a more detailed type of the OS unlike the `type` attribute.
+     * For example returns `CentOS Stream 9` instead of `RHEL`. Value aligns with the OS description in the engine UI.
+     * 
+     * NOTE: this attribute is currently only used for hosts.
+     * 
+     * @author Jasper Berton <jasper.berton@team.blue>
+     * @date 26 May 2025
+     * @status added
+     * @since 4.6.1
+     */
+    String description();
+
     Version version();
 }


### PR DESCRIPTION
added a new description field to OperatingSystem to make a more specific description of the OS that runs on a certain host available.

Fixes issue: https://github.com/oVirt/ovirt-engine-api-model/issues/105