### PR TITLE
Feature/nvme overtcp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *.class
 *.iml
 .idea/
+.classpath
+.project
+.settings/
 .bash_history
 .vscode/
 exported-artifacts/

--- a/src/main/java/types/Host.java
+++ b/src/main/java/types/Host.java
@@ -234,6 +234,17 @@ public interface Host extends Identified {
     String rootPassword();
 
     /**
+     * The NVMe host NQN used by this host for NVMe-oF initiator connections.
+     * This value is generated from `/etc/nvme/hostnqn` during host deployment.
+     *
+     * @author Thibaut Démaret <thibaut.demaret@worteks.com>
+     * @date 05 Jun 2026
+     * @status added
+     * @since 4.6
+     */
+    String nvmeHostNqn();
+
+    /**
      * The SSH definitions.
      *
      * @author Oved Ourfali <oourfali@redhat.com>

--- a/src/main/java/types/HostStorage.java
+++ b/src/main/java/types/HostStorage.java
@@ -190,6 +190,59 @@ public interface HostStorage extends Identified {
      */
     Property[] driverSensitiveOptions();
 
+  // NVMe-oF fields:
+  /**
+   * The NVMe Qualified Name (NQN) of the NVMe-oF target subsystem.
+   *
+   * @author Thibaut Démaret <thibaut.demaret@worteks.com>
+   * @date 05 Jun 2026
+   * @status added
+   * @since 4.6
+   */
+  String nqn();
+
+  /**
+   * The transport protocol for the NVMe-oF connection.
+   * Valid values are `tcp`, `rdma`, and `fc`. Defaults to `tcp`.
+   *
+   * @author Thibaut Démaret <thibaut.demaret@worteks.com>
+   * @date 05 Jun 2026
+   * @status added
+   * @since 4.6
+   */
+  String transport();
+
+  /**
+   * The NVMe-oF transport service identifier, typically the TCP port.
+   * Defaults to `4420`.
+   *
+   * @author Thibaut Démaret <thibaut.demaret@worteks.com>
+   * @date 05 Jun 2026
+   * @status added
+   * @since 4.6
+   */
+  String trsvcid();
+
+  /**
+   * The host NQN used by the initiator for NVMe-oF discovery and connection.
+   *
+   * @author Thibaut Démaret <thibaut.demaret@worteks.com>
+   * @date 05 Jun 2026
+   * @status added
+   * @since 4.6
+   */
+  String hostNqn();
+
+  /**
+   * The DH-HMAC-CHAP key for NVMe-oF in-band authentication.
+   *
+   * @author Thibaut Démaret <thibaut.demaret@worteks.com>
+   * @date 05 Jun 2026
+   * @status added
+   * @since 4.6
+   */
+  String dhchapKey();
+
 
   // Link to the host:
   @Link Host host();

--- a/src/main/java/types/LogicalUnit.java
+++ b/src/main/java/types/LogicalUnit.java
@@ -80,4 +80,14 @@ public interface LogicalUnit {
      */
     @Deprecated
     Boolean discardZeroesData();
+
+    /**
+     * The NVMe Qualified Name (NQN) of the NVMe-oF target subsystem.
+     *
+     * @author Thibaut Démaret <thibaut.demaret@worteks.com>
+     * @date 05 Jun 2026
+     * @status added
+     * @since 4.6
+     */
+    String nqn();
 }

--- a/src/main/java/types/StorageConnection.java
+++ b/src/main/java/types/StorageConnection.java
@@ -177,6 +177,60 @@ public interface StorageConnection extends Identified {
      */
     String portal();
 
+    // NVMe-oF fields:
+    /**
+     * The NVMe Qualified Name (NQN) of the NVMe-oF target subsystem.
+     *
+     * @author Thibaut Démaret <thibaut.demaret@worteks.com>
+     * @date 05 Jun 2026
+     * @status added
+     * @since 4.6
+     */
+    String nqn();
+
+    /**
+     * The transport protocol for the NVMe-oF connection.
+     * Valid values are `tcp`, `rdma`, and `fc`. Defaults to `tcp`.
+     *
+     * @author Thibaut Démaret <thibaut.demaret@worteks.com>
+     * @date 05 Jun 2026
+     * @status added
+     * @since 4.6
+     */
+    String transport();
+
+    /**
+     * The NVMe-oF transport service identifier, typically the TCP port.
+     * Defaults to `4420`.
+     *
+     * @author Thibaut Démaret <thibaut.demaret@worteks.com>
+     * @date 05 Jun 2026
+     * @status added
+     * @since 4.6
+     */
+    String trsvcid();
+
+    /**
+     * The host NQN used by the initiator for NVMe-oF discovery and connection.
+     *
+     * @author Thibaut Démaret <thibaut.demaret@worteks.com>
+     * @date 05 Jun 2026
+     * @status added
+     * @since 4.6
+     */
+    String hostNqn();
+
+    /**
+     * The DH-HMAC-CHAP key for NVMe-oF in-band authentication.
+     * This value is encrypted before storage in the database.
+     *
+     * @author Thibaut Démaret <thibaut.demaret@worteks.com>
+     * @date 05 Jun 2026
+     * @status added
+     * @since 4.6
+     */
+    String dhchapKey();
+
     /**
      * Link to the gluster volume, used by that storage domain.
      *

--- a/src/main/java/types/StorageType.java
+++ b/src/main/java/types/StorageType.java
@@ -118,5 +118,15 @@ public enum StorageType {
      * @status updated_by_docs
 
      */
-    MANAGED_BLOCK_STORAGE;
+    MANAGED_BLOCK_STORAGE,
+
+    /**
+     * NVMe over Fabrics (NVMe-oF) storage domain using TCP transport.
+     *
+     * @author Thibaut Démaret <thibaut.demaret@worteks.com>
+     * @date 05 Jun 2026
+     * @status added
+     * @since 4.6
+     */
+    NVMEOF;
 }


### PR DESCRIPTION
Add NVMe-oF/TCP storage domain support to oVirt. This is a block/shared storage domain type, analogous to iSCSI, using the built-in Linux NVMe 
initiator (nvme-cli). It supports both authenticated (DH-HMAC-CHAP) and non-authenticated NVMe-oF targets.

The feature try to be backend-agnostic for any NVMe/TCP target works (Ceph NVMe-oF Gateway is the reference implementation).

# Change :
- New storage domain type: nvmeof in REST API / Ansible / SDK
- Authentication : optional DH-HMAC-CHAP 
- Multipath : native NVMe multipath detected automatically; falls back to dm-mpath
- Host deployment: NVMe host NQN auto-detected from /etc/nvme/hostnqn

# Limitations :
- No iSCSI bond support for NVMe-oF
- NVMe-oF storage domain cannot be edited or imported via webadmin
