### PR TITLE
build: update build flow

### DIFF
--- a/.automation/build-rpm.sh
+++ b/.automation/build-rpm.sh
@@ -9,6 +9,7 @@ dnf builddep -y rpmbuild/SRPMS/*src.rpm
 rpmbuild \
     --define "_topmdir rpmbuild" \
     --define "_rpmdir rpmbuild" \
+    --define "release_suffix ${RELEASE_SUFFIX:-}" \
     --rebuild rpmbuild/SRPMS/*src.rpm
 
 # Move RPMs to exported artifacts

--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 
-# When building on GitHub we should use GITHUB_SHA environment variable, otherwise parse has from git
+# When building on GitHub we should use GITHUB_SHA environment variable, otherwise parse hash from git
 GIT_HASH=$(git rev-parse --short ${GITHUB_SHA:-HEAD})
 
 # Directory, where build artifacts will be stored, should be passed as the 1st parameter
@@ -9,24 +9,29 @@ ARTIFACTS_DIR=${1:-exported-artifacts}
 # Disabling tests can be passed as the 2nd parameter
 SKIP_TESTS=${2:-0}
 
-# Prepare the version string (with support for SNAPSHOT versioning)
-VERSION=$(mvn help:evaluate  -q -DforceStdout -Dexpression=project.version)
-VERSION=${VERSION/-SNAPSHOT/-0.$(date +%04Y%02m%02d%02H%02M).git${GIT_HASH}}
-IFS='-' read -ra VERSION <<< "$VERSION"
-RELEASE=${VERSION[1]-1}
+# Get version from Maven (strip -SNAPSHOT suffix if present).
+# RPM_VERSION env var overrides this (e.g. extracted from a git tag in CI).
+RAW_VERSION=$(mvn help:evaluate -q -DforceStdout -Dexpression=project.version)
+VERSION=${RPM_VERSION:-${RAW_VERSION%-SNAPSHOT}}
+
+# RPM release - default to 0.master, overridden by env for tagged/release builds
+PACKAGE_RPM_RELEASE=${PACKAGE_RPM_RELEASE:-0.master}
+
+# Release suffix - appended to release for snapshot builds, empty for tagged/release builds
+RELEASE_SUFFIX=${RELEASE_SUFFIX:-}
 
 # Prepare source archive
 [[ -d rpmbuild/SOURCES ]] || mkdir -p rpmbuild/SOURCES
-git archive --format=tar HEAD | gzip -9 > rpmbuild/SOURCES/ovirt-engine-api-model-$VERSION.tar.gz
+git archive --format=tar HEAD | gzip -9 > rpmbuild/SOURCES/ovirt-engine-api-model-${VERSION}.tar.gz
 
 # Generate AsciiDoc and HTML documentation
 mvn package -Pgenerate-adoc-html -Dadoc.linkcss=true
-cp target/doc.jar rpmbuild/SOURCES/ovirt-engine-api-model-doc-$VERSION.jar
+cp target/doc.jar rpmbuild/SOURCES/ovirt-engine-api-model-doc-${VERSION}.jar
 
-# Set version and release
+# Set version and release in the spec file
 sed \
     -e "s|@VERSION@|${VERSION}|g" \
-    -e "s|@RELEASE@|${RELEASE}|g" \
+    -e "s|@PACKAGE_RPM_RELEASE@|${PACKAGE_RPM_RELEASE}|g" \
     -e "s|@SKIP_TESTS@|${SKIP_TESTS}|g" \
     < ovirt-engine-api-model.spec.in \
     > ovirt-engine-api-model.spec
@@ -34,4 +39,5 @@ sed \
 # Build source package
 rpmbuild \
     -D "_topdir rpmbuild" \
+    --define "release_suffix ${RELEASE_SUFFIX}" \
     -bs ovirt-engine-api-model.spec

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,10 @@
+---
 name: build
+
 on:
   push:
     branches: [master]
+    tags: ['*']
   pull_request:
     branches: [master]
   workflow_dispatch:
@@ -40,6 +43,23 @@ jobs:
 
       - name: Mark git repo as safe
         run: git config --global --add safe.directory $(pwd)
+
+      - name: Set build environment
+        run: |
+          TAG=$(git tag --points-at HEAD | head -1)
+          if [[ -n "$TAG" ]]; then
+            if [[ "$TAG" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)$ ]]; then
+              echo "RPM_VERSION=${BASH_REMATCH[1]}" >> $GITHUB_ENV
+              echo "PACKAGE_RPM_RELEASE=${BASH_REMATCH[2]}" >> $GITHUB_ENV
+            elif [[ "$TAG" =~ ^([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+              echo "RPM_VERSION=${BASH_REMATCH[1]}" >> $GITHUB_ENV
+              echo "PACKAGE_RPM_RELEASE=1" >> $GITHUB_ENV
+            else
+              echo "PACKAGE_RPM_RELEASE=1" >> $GITHUB_ENV
+            fi
+          else
+            echo "RELEASE_SUFFIX=.$(date --utc +%Y%m%d%H%M%S).git$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          fi
 
       - name: Use cache for maven
         uses: actions/cache@v6

--- a/ovirt-engine-api-model.spec.in
+++ b/ovirt-engine-api-model.spec.in
@@ -1,6 +1,6 @@
 Name:		ovirt-engine-api-model
 Version:	@VERSION@
-Release:	@RELEASE@%{?dist}
+Release:	@PACKAGE_RPM_RELEASE@%{?release_suffix}%{?dist}
 Summary:	Model management tools for the oVirt Engine API.
 Group:		%{ovirt_product_group}
 License:	ASL 2.0


### PR DESCRIPTION
- Update the way version tags are added during build. Now we can tag a commit in github, and the correct version string will be used for the builds.
- Run the workflow on any tag, so it builds tags in branches also.